### PR TITLE
Add dedicated informational pages and open admissions links in new tab

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>대학소개 | 서울 사이버 캠퍼스</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="site-header">
+        <div class="container">
+            <a class="logo" href="index.html">Seoul Cyber</a>
+            <nav class="main-nav" aria-label="주요 메뉴">
+                <ul>
+                    <li><a href="about.html">대학소개</a></li>
+                    <li><a href="programs.html">전공안내</a></li>
+                    <li><a href="admissions.html">입학안내</a></li>
+                    <li><a href="news.html">새소식</a></li>
+                    <li><a href="support.html">학생지원</a></li>
+                </ul>
+            </nav>
+            <div class="cta-group">
+                <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero">
+            <div class="container">
+                <div class="hero-text">
+                    <span class="badge">About Seoul Cyber</span>
+                    <h1>미래형 온라인 대학, 서울 사이버 캠퍼스</h1>
+                    <p>
+                        서울 사이버 캠퍼스는 디지털 혁신 기술과 학습자 중심의 교육 철학을 바탕으로 설립된 미래형 고등 교육 기관입니다.
+                        시간과 장소의 제약을 넘어 언제 어디서나 고품질 수업을 제공하며 학습자의 성장을 돕습니다.
+                    </p>
+                </div>
+                <div class="hero-visual" aria-hidden="true">
+                    <div class="floating-card">
+                        <strong>핵심 가치</strong>
+                        <p>창의, 혁신, 포용</p>
+                        <a href="#vision">교육 비전 자세히 보기</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="vision" class="section about">
+            <div class="container split">
+                <div class="text">
+                    <h2>서울 사이버 캠퍼스 소개</h2>
+                    <p>
+                        첨단 디지털 학습 환경을 기반으로 누구나 꿈을 이룰 수 있도록 설계된 온라인 대학입니다.
+                        24시간 언제든지 수강 가능한 강의와 실습, 체계적인 학사 관리 시스템을 통해 학습자 중심의 교육을 제공합니다.
+                    </p>
+                    <ul class="feature-list">
+                        <li>실무 중심의 커리큘럼과 프로젝트 학습</li>
+                        <li>전문 교수진과의 밀착형 멘토링</li>
+                        <li>국내·외 산업체와 연계한 취업 지원 프로그램</li>
+                    </ul>
+                    <a class="link" href="#history">연혁 살펴보기 →</a>
+                </div>
+                <div class="highlight-card" role="img" aria-label="온라인 강의를 듣는 학생">
+                    <div class="stat">
+                        <span class="number">95%</span>
+                        <span class="label">재학생 만족도</span>
+                    </div>
+                    <p>
+                        학습자 맞춤형 지원 서비스와 디지털 콘텐츠 혁신을 통해 높은 교육 만족도를 유지하고 있습니다.
+                    </p>
+                </div>
+            </div>
+        </section>
+
+        <section id="history" class="section">
+            <div class="container">
+                <div class="section-heading">
+                    <h2>연혁 및 성과</h2>
+                    <p>서울 사이버 캠퍼스가 걸어온 길을 소개합니다.</p>
+                </div>
+                <div class="program-grid">
+                    <article class="program-card">
+                        <h3>2015년</h3>
+                        <p>서울 사이버 캠퍼스 설립 및 온라인 학사 시스템 구축.</p>
+                    </article>
+                    <article class="program-card">
+                        <h3>2018년</h3>
+                        <p>AI 학습 지원 플랫폼 도입 및 글로벌 산학 협력 체결.</p>
+                    </article>
+                    <article class="program-card">
+                        <h3>2021년</h3>
+                        <p>국내 최초 메타버스 캠퍼스 개설, 학생 만족도 90% 달성.</p>
+                    </article>
+                    <article class="program-card">
+                        <h3>2024년</h3>
+                        <p>전 학부 디지털 트윈 실습 환경 구축 및 재학생 만족도 95% 달성.</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer-top">
+            <div>
+                <strong class="logo">Seoul Cyber</strong>
+                <p>서울특별시 ○○구 ○○로 123 | TEL 02-1234-5678 | 대표자 홍길동</p>
+                <p>사업자등록번호 123-45-67890 | 통신판매업 신고번호 제2024-서울-00000호</p>
+            </div>
+            <div class="footer-links">
+                <h3>바로가기</h3>
+                <ul>
+                    <li><a href="#privacy">개인정보처리방침</a></li>
+                    <li><a href="#terms">이용약관</a></li>
+                    <li><a href="#policy">원격평생교육 신고</a></li>
+                </ul>
+            </div>
+            <div class="footer-links">
+                <h3>고객센터</h3>
+                <ul>
+                    <li><a href="#faq">FAQ</a></li>
+                    <li><a href="#contact">1:1 문의</a></li>
+                    <li><a href="#location">오시는 길</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="container footer-bottom">
+            <small>© 2024 Seoul Cyber Campus. All rights reserved.</small>
+            <div class="social">
+                <a href="#" aria-label="유튜브">YouTube</a>
+                <a href="#" aria-label="인스타그램">Instagram</a>
+                <a href="#" aria-label="페이스북">Facebook</a>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/admissions.html
+++ b/admissions.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>입학안내 | 서울 사이버 캠퍼스</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="site-header">
+        <div class="container">
+            <a class="logo" href="index.html">Seoul Cyber</a>
+            <nav class="main-nav" aria-label="주요 메뉴">
+                <ul>
+                    <li><a href="about.html">대학소개</a></li>
+                    <li><a href="programs.html">전공안내</a></li>
+                    <li><a href="admissions.html">입학안내</a></li>
+                    <li><a href="news.html">새소식</a></li>
+                    <li><a href="support.html">학생지원</a></li>
+                </ul>
+            </nav>
+            <div class="cta-group">
+                <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero">
+            <div class="container">
+                <div class="hero-text">
+                    <span class="badge">Admissions</span>
+                    <h1>서울 사이버 캠퍼스 입학 안내</h1>
+                    <p>
+                        신입학과 편입학 전형, 등록금, 장학 혜택, 학사 일정 등 입학에 필요한 모든 정보를 한 곳에서 확인하세요.
+                        맞춤형 상담을 통해 학습 여정을 함께 설계해 드립니다.
+                    </p>
+                    <div class="hero-actions">
+                        <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">지금 지원하기</a>
+                        <a class="btn ghost" href="#process">전형 절차 보기</a>
+                    </div>
+                </div>
+                <div class="hero-visual" aria-hidden="true">
+                    <div class="floating-card">
+                        <strong>원서 접수</strong>
+                        <p>2024.12.01 ~ 2024.12.31</p>
+                        <a href="#timeline">세부 일정 확인</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="process" class="section admissions">
+            <div class="container split">
+                <div>
+                    <h2>입학 전형 절차</h2>
+                    <p>간편한 온라인 접수부터 화상 면접까지, 완전한 온라인 전형으로 진행됩니다.</p>
+                    <ol class="feature-list">
+                        <li>온라인 지원서 작성 및 제출</li>
+                        <li>서류 심사 및 전형료 납부 안내</li>
+                        <li>화상 면접 전형</li>
+                        <li>최종 합격자 발표 및 등록</li>
+                    </ol>
+                    <a class="btn ghost" href="support.html">상담 예약하기</a>
+                </div>
+                <aside class="admission-card">
+                    <h3>상담 예약</h3>
+                    <p>입학 전문 상담사가 궁금증을 해결해 드립니다.</p>
+                    <form>
+                        <label>
+                            이름
+                            <input type="text" name="name" placeholder="홍길동" required />
+                        </label>
+                        <label>
+                            연락처
+                            <input type="tel" name="phone" placeholder="010-1234-5678" required />
+                        </label>
+                        <label>
+                            상담 희망일
+                            <input type="date" name="date" required />
+                        </label>
+                        <button type="submit" class="btn primary">예약 신청</button>
+                    </form>
+                </aside>
+            </div>
+        </section>
+
+        <section id="timeline" class="section">
+            <div class="container">
+                <div class="section-heading">
+                    <h2>2025학년도 주요 일정</h2>
+                    <p>입학 과정별 세부 일정을 확인하세요.</p>
+                </div>
+                <div class="program-grid">
+                    <article class="program-card">
+                        <h3>원서 접수</h3>
+                        <p>2024.12.01 ~ 2024.12.31 (온라인 접수)</p>
+                    </article>
+                    <article class="program-card">
+                        <h3>면접 전형</h3>
+                        <p>2025.01.10 ~ 2025.01.15 (화상 면접)</p>
+                    </article>
+                    <article class="program-card">
+                        <h3>합격 발표</h3>
+                        <p>2025.01.25 (홈페이지 및 문자 안내)</p>
+                    </article>
+                    <article class="program-card">
+                        <h3>등록 및 오리엔테이션</h3>
+                        <p>2025.02.01 ~ 2025.02.10 (온라인 등록 및 웰컴 세션)</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="section">
+            <div class="container split">
+                <div>
+                    <h2>장학 및 재정 지원</h2>
+                    <p>다양한 장학 혜택과 학자금 대출 지원으로 학습 부담을 줄여드립니다.</p>
+                    <ul class="feature-list">
+                        <li>신입생 성적 우수 장학금</li>
+                        <li>재학생 맞춤형 성과 장학금</li>
+                        <li>산업체 재직자 학비 지원 프로그램</li>
+                    </ul>
+                </div>
+                <div class="highlight-card" role="img" aria-label="장학 수여식">
+                    <div class="stat">
+                        <span class="number">70%</span>
+                        <span class="label">장학 수혜 비율</span>
+                    </div>
+                    <p>재학생 중 70% 이상이 장학 혜택을 받고 있습니다.</p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer-top">
+            <div>
+                <strong class="logo">Seoul Cyber</strong>
+                <p>서울특별시 ○○구 ○○로 123 | TEL 02-1234-5678 | 대표자 홍길동</p>
+                <p>사업자등록번호 123-45-67890 | 통신판매업 신고번호 제2024-서울-00000호</p>
+            </div>
+            <div class="footer-links">
+                <h3>바로가기</h3>
+                <ul>
+                    <li><a href="#privacy">개인정보처리방침</a></li>
+                    <li><a href="#terms">이용약관</a></li>
+                    <li><a href="#policy">원격평생교육 신고</a></li>
+                </ul>
+            </div>
+            <div class="footer-links">
+                <h3>고객센터</h3>
+                <ul>
+                    <li><a href="#faq">FAQ</a></li>
+                    <li><a href="#contact">1:1 문의</a></li>
+                    <li><a href="#location">오시는 길</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="container footer-bottom">
+            <small>© 2024 Seoul Cyber Campus. All rights reserved.</small>
+            <div class="social">
+                <a href="#" aria-label="유튜브">YouTube</a>
+                <a href="#" aria-label="인스타그램">Instagram</a>
+                <a href="#" aria-label="페이스북">Facebook</a>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -12,18 +12,18 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="#">Seoul Cyber</a>
+            <a class="logo" href="index.html">Seoul Cyber</a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
-                    <li><a href="#about">대학소개</a></li>
-                    <li><a href="#programs">전공안내</a></li>
-                    <li><a href="#admissions">입학안내</a></li>
-                    <li><a href="#news">새소식</a></li>
-                    <li><a href="#support">학생지원</a></li>
+                    <li><a href="about.html">대학소개</a></li>
+                    <li><a href="programs.html">전공안내</a></li>
+                    <li><a href="admissions.html">입학안내</a></li>
+                    <li><a href="news.html">새소식</a></li>
+                    <li><a href="support.html">학생지원</a></li>
                 </ul>
             </nav>
             <div class="cta-group">
-                <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e">입학지원</a>
+                <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>
         </div>
     </header>
@@ -269,7 +269,7 @@
             <div class="container">
                 <h2>나만의 학습 여정을 시작하세요</h2>
                 <p>서울 사이버 캠퍼스에서 미래를 설계하고 새로운 도전을 경험해 보세요.</p>
-                <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e">지금 지원하기</a>
+                <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">지금 지원하기</a>
             </div>
         </section>
     </main>

--- a/news.html
+++ b/news.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>새소식 | 서울 사이버 캠퍼스</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="site-header">
+        <div class="container">
+            <a class="logo" href="index.html">Seoul Cyber</a>
+            <nav class="main-nav" aria-label="주요 메뉴">
+                <ul>
+                    <li><a href="about.html">대학소개</a></li>
+                    <li><a href="programs.html">전공안내</a></li>
+                    <li><a href="admissions.html">입학안내</a></li>
+                    <li><a href="news.html">새소식</a></li>
+                    <li><a href="support.html">학생지원</a></li>
+                </ul>
+            </nav>
+            <div class="cta-group">
+                <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero">
+            <div class="container">
+                <div class="hero-text">
+                    <span class="badge">Campus News</span>
+                    <h1>서울 사이버 캠퍼스의 최신 소식을 만나보세요</h1>
+                    <p>
+                        학사 일정, 장학 안내, 커리어 행사 등 캠퍼스의 다양한 소식을 실시간으로 전해드립니다.
+                        관심 있는 소식을 확인하고 참여 일정을 놓치지 마세요.
+                    </p>
+                </div>
+                <div class="hero-visual" aria-hidden="true">
+                    <div class="floating-card">
+                        <strong>뉴스레터 구독</strong>
+                        <p>매월 캠퍼스 소식 받아보기</p>
+                        <a href="#newsletter">신청하기</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section news">
+            <div class="container">
+                <div class="section-heading">
+                    <h2>최신 뉴스</h2>
+                    <p>주요 공지와 행사를 확인하세요.</p>
+                </div>
+                <div class="news-grid">
+                    <article class="news-card">
+                        <span class="tag">공지</span>
+                        <h3>2024학년도 2학기 장학금 신청 안내</h3>
+                        <time datetime="2024-09-20">2024.09.20</time>
+                        <p>장학금 유형별 신청 방법과 제출 서류를 확인하고 기간 내 접수하세요.</p>
+                    </article>
+                    <article class="news-card">
+                        <span class="tag">행사</span>
+                        <h3>메타버스 진로 박람회 개최</h3>
+                        <time datetime="2024-10-05">2024.10.05</time>
+                        <p>업계 전문가와 함께하는 최신 산업 트렌드 세미나 및 네트워킹 행사.</p>
+                    </article>
+                    <article class="news-card">
+                        <span class="tag">채용</span>
+                        <h3>산학협력 프로젝트 참여자 모집</h3>
+                        <time datetime="2024-09-30">2024.09.30</time>
+                        <p>기업 연계형 현장 실습과 채용 연계 프로그램 참가자를 선발합니다.</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" id="newsletter">
+            <div class="container split">
+                <div>
+                    <h2>뉴스레터 구독</h2>
+                    <p>서울 사이버 캠퍼스의 최신 소식과 이벤트를 이메일로 받아보세요.</p>
+                    <ul class="feature-list">
+                        <li>월간 주요 뉴스 요약</li>
+                        <li>이벤트 및 특강 우선 초대</li>
+                        <li>장학 및 프로그램 업데이트</li>
+                    </ul>
+                </div>
+                <div class="support-cta">
+                    <h3>간편 구독 신청</h3>
+                    <p>이메일 주소를 입력하고 구독 버튼을 눌러주세요.</p>
+                    <form>
+                        <label>
+                            이메일
+                            <input type="email" name="email" placeholder="you@example.com" required />
+                        </label>
+                        <button type="submit" class="btn primary">구독하기</button>
+                    </form>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer-top">
+            <div>
+                <strong class="logo">Seoul Cyber</strong>
+                <p>서울특별시 ○○구 ○○로 123 | TEL 02-1234-5678 | 대표자 홍길동</p>
+                <p>사업자등록번호 123-45-67890 | 통신판매업 신고번호 제2024-서울-00000호</p>
+            </div>
+            <div class="footer-links">
+                <h3>바로가기</h3>
+                <ul>
+                    <li><a href="#privacy">개인정보처리방침</a></li>
+                    <li><a href="#terms">이용약관</a></li>
+                    <li><a href="#policy">원격평생교육 신고</a></li>
+                </ul>
+            </div>
+            <div class="footer-links">
+                <h3>고객센터</h3>
+                <ul>
+                    <li><a href="#faq">FAQ</a></li>
+                    <li><a href="#contact">1:1 문의</a></li>
+                    <li><a href="#location">오시는 길</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="container footer-bottom">
+            <small>© 2024 Seoul Cyber Campus. All rights reserved.</small>
+            <div class="social">
+                <a href="#" aria-label="유튜브">YouTube</a>
+                <a href="#" aria-label="인스타그램">Instagram</a>
+                <a href="#" aria-label="페이스북">Facebook</a>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/programs.html
+++ b/programs.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="site-header">
+        <div class="container">
+            <a class="logo" href="index.html">Seoul Cyber</a>
+            <nav class="main-nav" aria-label="주요 메뉴">
+                <ul>
+                    <li><a href="about.html">대학소개</a></li>
+                    <li><a href="programs.html">전공안내</a></li>
+                    <li><a href="admissions.html">입학안내</a></li>
+                    <li><a href="news.html">새소식</a></li>
+                    <li><a href="support.html">학생지원</a></li>
+                </ul>
+            </nav>
+            <div class="cta-group">
+                <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero">
+            <div class="container">
+                <div class="hero-text">
+                    <span class="badge">Academic Programs</span>
+                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
+                    <p>
+                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
+                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
+                    </p>
+                </div>
+                <div class="hero-visual" aria-hidden="true">
+                    <div class="floating-card">
+                        <strong>전공 상담</strong>
+                        <p>전공 선택이 고민된다면?</p>
+                        <a href="support.html">학생지원으로 이동</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section programs">
+            <div class="container">
+                <div class="section-heading">
+                    <h2>학부 및 전공</h2>
+                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
+                </div>
+                <div class="program-grid">
+                    <article class="program-card">
+                        <h3>AI · 데이터 사이언스</h3>
+                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
+                        <a href="#ai">세부 전공 보기</a>
+                    </article>
+                    <article class="program-card">
+                        <h3>디지털 비즈니스</h3>
+                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
+                        <a href="#business">세부 전공 보기</a>
+                    </article>
+                    <article class="program-card">
+                        <h3>휴먼서비스</h3>
+                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
+                        <a href="#human">세부 전공 보기</a>
+                    </article>
+                    <article class="program-card">
+                        <h3>문화예술 · 디자인</h3>
+                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
+                        <a href="#design">세부 전공 보기</a>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="ai" class="section">
+            <div class="container split">
+                <div>
+                    <h2>AI · 데이터 사이언스 학부</h2>
+                    <p>
+                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
+                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
+                    </p>
+                    <ul class="feature-list">
+                        <li>AI 프로그래밍 및 알고리즘 심화</li>
+                        <li>데이터 시각화와 분석 실습</li>
+                        <li>산업체 연계 캡스톤 프로젝트</li>
+                    </ul>
+                </div>
+                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
+                    <div class="stat">
+                        <span class="number">120+</span>
+                        <span class="label">AI 산업체 협약</span>
+                    </div>
+                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="business" class="section">
+            <div class="container split">
+                <div>
+                    <h2>디지털 비즈니스 학부</h2>
+                    <p>
+                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
+                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
+                    </p>
+                    <ul class="feature-list">
+                        <li>글로벌 이커머스 실습</li>
+                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
+                        <li>창업 멘토링 및 투자 연계</li>
+                    </ul>
+                </div>
+                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
+                    <div class="stat">
+                        <span class="number">85%</span>
+                        <span class="label">창업 실무 만족도</span>
+                    </div>
+                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="human" class="section">
+            <div class="container split">
+                <div>
+                    <h2>휴먼서비스 학부</h2>
+                    <p>
+                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
+                        사례 연구를 통해 현장 대응 능력을 강화합니다.
+                    </p>
+                    <ul class="feature-list">
+                        <li>상담 이론 및 사례 기반 훈련</li>
+                        <li>사회복지 기관과의 연계 실습</li>
+                        <li>심리평가 및 프로그램 기획 역량 강화</li>
+                    </ul>
+                </div>
+                <div class="highlight-card" role="img" aria-label="상담 장면">
+                    <div class="stat">
+                        <span class="number">1,200+</span>
+                        <span class="label">현장 실습 시간</span>
+                    </div>
+                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="design" class="section">
+            <div class="container split">
+                <div>
+                    <h2>문화예술 · 디자인 학부</h2>
+                    <p>
+                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
+                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
+                    </p>
+                    <ul class="feature-list">
+                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
+                        <li>산업체 협업 디자인 프로젝트</li>
+                        <li>국제 공모전 참여 및 피드백 세션</li>
+                    </ul>
+                </div>
+                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
+                    <div class="stat">
+                        <span class="number">60+</span>
+                        <span class="label">포트폴리오 경진대회 수상</span>
+                    </div>
+                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer-top">
+            <div>
+                <strong class="logo">Seoul Cyber</strong>
+                <p>서울특별시 ○○구 ○○로 123 | TEL 02-1234-5678 | 대표자 홍길동</p>
+                <p>사업자등록번호 123-45-67890 | 통신판매업 신고번호 제2024-서울-00000호</p>
+            </div>
+            <div class="footer-links">
+                <h3>바로가기</h3>
+                <ul>
+                    <li><a href="#privacy">개인정보처리방침</a></li>
+                    <li><a href="#terms">이용약관</a></li>
+                    <li><a href="#policy">원격평생교육 신고</a></li>
+                </ul>
+            </div>
+            <div class="footer-links">
+                <h3>고객센터</h3>
+                <ul>
+                    <li><a href="#faq">FAQ</a></li>
+                    <li><a href="#contact">1:1 문의</a></li>
+                    <li><a href="#location">오시는 길</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="container footer-bottom">
+            <small>© 2024 Seoul Cyber Campus. All rights reserved.</small>
+            <div class="social">
+                <a href="#" aria-label="유튜브">YouTube</a>
+                <a href="#" aria-label="인스타그램">Instagram</a>
+                <a href="#" aria-label="페이스북">Facebook</a>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/support.html
+++ b/support.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>학생지원 | 서울 사이버 캠퍼스</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="site-header">
+        <div class="container">
+            <a class="logo" href="index.html">Seoul Cyber</a>
+            <nav class="main-nav" aria-label="주요 메뉴">
+                <ul>
+                    <li><a href="about.html">대학소개</a></li>
+                    <li><a href="programs.html">전공안내</a></li>
+                    <li><a href="admissions.html">입학안내</a></li>
+                    <li><a href="news.html">새소식</a></li>
+                    <li><a href="support.html">학생지원</a></li>
+                </ul>
+            </nav>
+            <div class="cta-group">
+                <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero">
+            <div class="container">
+                <div class="hero-text">
+                    <span class="badge">Student Support</span>
+                    <h1>학생의 성장을 돕는 전방위 지원 서비스</h1>
+                    <p>
+                        학습 코칭부터 커리어 개발, 커뮤니티 활동까지 학생의 여정을 세심하게 지원합니다.
+                        필요에 따라 맞춤형 프로그램을 신청하고 전문가의 도움을 받아보세요.
+                    </p>
+                </div>
+                <div class="hero-visual" aria-hidden="true">
+                    <div class="floating-card">
+                        <strong>1:1 상담센터</strong>
+                        <p>전담 코치와의 주간 상담</p>
+                        <a href="#coaching">상담 프로그램</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section support">
+            <div class="container split">
+                <div>
+                    <h2>학생 지원 서비스</h2>
+                    <p>재학생을 위한 맞춤형 학습 지원과 커리어 개발 프로그램을 제공합니다.</p>
+                    <ul class="support-list">
+                        <li>
+                            <strong>학습 코칭</strong>
+                            <span>전문 학습 코치가 개인 맞춤 학습 계획을 제안합니다.</span>
+                        </li>
+                        <li>
+                            <strong>커리어 센터</strong>
+                            <span>채용 정보, 이력서 컨설팅, 모의 면접을 지원합니다.</span>
+                        </li>
+                        <li>
+                            <strong>학생 커뮤니티</strong>
+                            <span>다양한 동아리와 프로젝트 기반 교류 기회 제공.</span>
+                        </li>
+                    </ul>
+                </div>
+                <div class="support-cta">
+                    <h3>온라인 학습 가이드</h3>
+                    <p>원격 수업 참여를 위한 기술 가이드와 학습 도구 활용법을 확인하세요.</p>
+                    <a class="btn ghost" href="#guide">가이드 다운로드</a>
+                </div>
+            </div>
+        </section>
+
+        <section id="coaching" class="section">
+            <div class="container split">
+                <div>
+                    <h2>학습 코칭 프로그램</h2>
+                    <p>전문 코치가 학습 목표 설정, 시간 관리, 학습 전략 수립을 도와드립니다.</p>
+                    <ul class="feature-list">
+                        <li>개인별 학습 진단 및 목표 설정</li>
+                        <li>주간 피드백과 진도 관리</li>
+                        <li>학습 동기 부여 워크숍 제공</li>
+                    </ul>
+                </div>
+                <div class="highlight-card" role="img" aria-label="온라인 상담 장면">
+                    <div class="stat">
+                        <span class="number">1:1</span>
+                        <span class="label">맞춤 코칭</span>
+                    </div>
+                    <p>온라인 화상 상담으로 언제 어디서나 코칭을 받을 수 있습니다.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="section">
+            <div class="container split">
+                <div>
+                    <h2>커리어 개발 지원</h2>
+                    <p>취업 역량을 강화하기 위한 다양한 프로그램을 운영합니다.</p>
+                    <ul class="feature-list">
+                        <li>이력서 및 포트폴리오 클리닉</li>
+                        <li>산업체 멘토링 및 직무 특강</li>
+                        <li>인턴십 및 취업 연계 프로그램</li>
+                    </ul>
+                </div>
+                <div class="highlight-card" role="img" aria-label="커리어 상담">
+                    <div class="stat">
+                        <span class="number">92%</span>
+                        <span class="label">취업 만족도</span>
+                    </div>
+                    <p>전문 커리어 코치와의 1:1 상담으로 진로 설계를 지원합니다.</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="guide" class="section">
+            <div class="container">
+                <div class="section-heading">
+                    <h2>학습 가이드 자료실</h2>
+                    <p>원격 학습에 필요한 매뉴얼과 실습 가이드를 다운로드하세요.</p>
+                </div>
+                <div class="program-grid">
+                    <article class="program-card">
+                        <h3>학습 플랫폼 이용 안내</h3>
+                        <p>LMS 접속 방법, 수강 신청, 과제 제출 절차를 상세히 안내합니다.</p>
+                        <a href="#">PDF 다운로드</a>
+                    </article>
+                    <article class="program-card">
+                        <h3>화상 수업 체크리스트</h3>
+                        <p>원활한 화상 강의 참여를 위한 장비 및 환경 점검 항목을 제공합니다.</p>
+                        <a href="#">체크리스트 받기</a>
+                    </article>
+                    <article class="program-card">
+                        <h3>학습 도구 활용법</h3>
+                        <p>노트 필기 앱, 협업 툴 등 학습 효율을 높이는 도구 활용법을 소개합니다.</p>
+                        <a href="#">가이드 보기</a>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <div class="container footer-top">
+            <div>
+                <strong class="logo">Seoul Cyber</strong>
+                <p>서울특별시 ○○구 ○○로 123 | TEL 02-1234-5678 | 대표자 홍길동</p>
+                <p>사업자등록번호 123-45-67890 | 통신판매업 신고번호 제2024-서울-00000호</p>
+            </div>
+            <div class="footer-links">
+                <h3>바로가기</h3>
+                <ul>
+                    <li><a href="#privacy">개인정보처리방침</a></li>
+                    <li><a href="#terms">이용약관</a></li>
+                    <li><a href="#policy">원격평생교육 신고</a></li>
+                </ul>
+            </div>
+            <div class="footer-links">
+                <h3>고객센터</h3>
+                <ul>
+                    <li><a href="#faq">FAQ</a></li>
+                    <li><a href="#contact">1:1 문의</a></li>
+                    <li><a href="#location">오시는 길</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="container footer-bottom">
+            <small>© 2024 Seoul Cyber Campus. All rights reserved.</small>
+            <div class="social">
+                <a href="#" aria-label="유튜브">YouTube</a>
+                <a href="#" aria-label="인스타그램">Instagram</a>
+                <a href="#" aria-label="페이스북">Facebook</a>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated pages for 대학소개, 전공안내, 입학안내, 새소식, 학생지원 with tailored content that reuses the main site styling
- update the main navigation to route to the new standalone pages and keep the site logo linking back to the home page
- ensure the 입학지원 and 지금 지원하기 buttons open Kakao admissions in a new tab for a smoother user experience

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ddfe22430c833287d0018d32edd935