### PR TITLE
Tailor mega menus for all primary navigation links

### DIFF
--- a/about.html
+++ b/about.html
@@ -97,13 +97,269 @@
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>

--- a/academics.html
+++ b/academics.html
@@ -97,13 +97,269 @@
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>
@@ -158,7 +414,7 @@
             </div>
         </section>
 
-        <section class="section about">
+        <section id="policies" class="section about">
             <div class="container split">
                 <div class="text">
                     <h2>학사 제도 안내</h2>

--- a/admissions.html
+++ b/admissions.html
@@ -97,13 +97,269 @@
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>

--- a/campus-life.html
+++ b/campus-life.html
@@ -97,13 +97,269 @@
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>
@@ -162,7 +418,7 @@
             </div>
         </section>
 
-        <section class="section about">
+        <section id="experience" class="section about">
             <div class="container split">
                 <div class="text">
                     <h2>학생 경험 지원</h2>

--- a/convergence.html
+++ b/convergence.html
@@ -97,13 +97,269 @@
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>
@@ -157,7 +413,7 @@
             </div>
         </section>
 
-        <section class="section about">
+        <section id="projects" class="section about">
             <div class="container split">
                 <div class="text">
                     <h2>산업체 연계 프로젝트</h2>

--- a/index.html
+++ b/index.html
@@ -97,13 +97,269 @@
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>

--- a/news.html
+++ b/news.html
@@ -97,13 +97,269 @@
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>

--- a/programs.html
+++ b/programs.html
@@ -97,13 +97,269 @@
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>
@@ -131,7 +387,7 @@
             </div>
         </section>
 
-        <section class="section programs">
+        <section id="departments" class="section programs">
             <div class="container">
                 <div class="section-heading">
                     <h2>학부 및 전공</h2>

--- a/support.html
+++ b/support.html
@@ -97,13 +97,269 @@
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>


### PR DESCRIPTION
## Summary
- replace the duplicated admissions dropdown with contextual mega menus for 학과소개, 교육융합특성화 과정, 학사안내, 대학생활, and 학생지원
- add in-page anchors so each mega menu link jumps to the corresponding program, 학사, 융합과정, and 캠퍼스 생활 section content

## Testing
- not run (static HTML updates)

------
https://chatgpt.com/codex/tasks/task_e_68de0d839a648332859b0cce45498f3d