### PR TITLE
Add standalone pages for admissions submenu and simplify navigation icons

### DIFF
--- a/about.html
+++ b/about.html
@@ -23,52 +23,52 @@
                                     <section class="mega-section">
                                         <h3>총장실</h3>
                                         <ul>
-                                            <li><a href="#">인사말</a></li>
+                                            <li><a href="greeting.html">인사말</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>학교법인</h3>
                                         <ul>
-                                            <li><a href="#">법인소개</a></li>
-                                            <li><a href="#">예결산공시</a></li>
-                                            <li><a href="#">기부금품</a></li>
+                                            <li><a href="foundation.html">법인소개</a></li>
+                                            <li><a href="financial-reports.html">예결산공시</a></li>
+                                            <li><a href="donations.html">기부금품</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>비전</h3>
                                         <ul>
-                                            <li><a href="#">교육이념</a></li>
-                                            <li><a href="#">SDU 대학특성화</a></li>
-                                            <li><a href="#">SDU 2025</a></li>
+                                            <li><a href="education-philosophy.html">교육이념</a></li>
+                                            <li><a href="sdu-specialization.html">SDU 대학특성화</a></li>
+                                            <li><a href="sdu-2025.html">SDU 2025</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">Why SDU</a>
+                                        <a class="mega-heading" href="why-sdu.html">Why SDU</a>
                                     </section>
                                 </div>
                                 <div class="mega-column">
                                     <section class="mega-section">
                                         <h3>대학정보</h3>
                                         <ul>
-                                            <li><a href="#">소개</a></li>
-                                            <li><a href="#">조직도</a></li>
-                                            <li><a href="#">현황</a></li>
-                                            <li><a href="#">UI</a></li>
-                                            <li><a href="#">대학정보공시</a></li>
-                                            <li><a href="#">정보공개</a></li>
-                                            <li><a href="#">전화번호안내</a></li>
-                                            <li><a href="#">찾아오시는길</a></li>
+                                            <li><a href="university-overview.html">소개</a></li>
+                                            <li><a href="organization.html">조직도</a></li>
+                                            <li><a href="status.html">현황</a></li>
+                                            <li><a href="ui-guidelines.html">UI</a></li>
+                                            <li><a href="information-disclosure.html">대학정보공시</a></li>
+                                            <li><a href="public-info.html">정보공개</a></li>
+                                            <li><a href="contact-directory.html">전화번호안내</a></li>
+                                            <li><a href="directions.html">찾아오시는길</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">SDU 사회공헌</a>
+                                        <a class="mega-heading" href="social-contribution.html">SDU 사회공헌</a>
                                     </section>
                                     <section class="mega-section">
                                         <h3>사이버홍보실</h3>
                                         <ul>
-                                            <li><a href="#">보도기사</a></li>
-                                            <li><a href="#">대학 인증수상</a></li>
-                                            <li><a href="#">광고자료실</a></li>
+                                            <li><a href="press.html">보도기사</a></li>
+                                            <li><a href="awards.html">대학 인증수상</a></li>
+                                            <li><a href="media-kit.html">광고자료실</a></li>
                                         </ul>
                                     </section>
                                 </div>
@@ -76,34 +76,290 @@
                                     <section class="mega-section">
                                         <h3>입학안내</h3>
                                         <ul>
-                                            <li><a href="#">산업협력</a></li>
-                                            <li><a href="#">학교관계</a></li>
-                                            <li><a href="#">제휴협력</a></li>
+                                            <li><a href="industry-collaboration.html">산업협력</a></li>
+                                            <li><a href="school-relations.html">학교관계</a></li>
+                                            <li><a href="partnerships.html">제휴협력</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>교육원</h3>
                                         <ul>
-                                            <li><a href="#">전임교직원정보</a></li>
-                                            <li><a href="#">시간강사정보</a></li>
-                                            <li><a href="#">비전임교원(현황)</a></li>
-                                            <li><a href="#">튜터현황</a></li>
+                                            <li><a href="faculty-staff.html">전임교직원정보</a></li>
+                                            <li><a href="adjunct-faculty.html">시간강사정보</a></li>
+                                            <li><a href="non-tenure-faculty.html">비전임교원(현황)</a></li>
+                                            <li><a href="tutor-overview.html">튜터현황</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">입시자료공고</a>
+                                        <a class="mega-heading" href="admissions-bulletin.html">입시자료공고</a>
                                     </section>
                                 </div>
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>

--- a/academics.html
+++ b/academics.html
@@ -23,52 +23,52 @@
                                     <section class="mega-section">
                                         <h3>총장실</h3>
                                         <ul>
-                                            <li><a href="#">인사말</a></li>
+                                            <li><a href="greeting.html">인사말</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>학교법인</h3>
                                         <ul>
-                                            <li><a href="#">법인소개</a></li>
-                                            <li><a href="#">예결산공시</a></li>
-                                            <li><a href="#">기부금품</a></li>
+                                            <li><a href="foundation.html">법인소개</a></li>
+                                            <li><a href="financial-reports.html">예결산공시</a></li>
+                                            <li><a href="donations.html">기부금품</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>비전</h3>
                                         <ul>
-                                            <li><a href="#">교육이념</a></li>
-                                            <li><a href="#">SDU 대학특성화</a></li>
-                                            <li><a href="#">SDU 2025</a></li>
+                                            <li><a href="education-philosophy.html">교육이념</a></li>
+                                            <li><a href="sdu-specialization.html">SDU 대학특성화</a></li>
+                                            <li><a href="sdu-2025.html">SDU 2025</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">Why SDU</a>
+                                        <a class="mega-heading" href="why-sdu.html">Why SDU</a>
                                     </section>
                                 </div>
                                 <div class="mega-column">
                                     <section class="mega-section">
                                         <h3>대학정보</h3>
                                         <ul>
-                                            <li><a href="#">소개</a></li>
-                                            <li><a href="#">조직도</a></li>
-                                            <li><a href="#">현황</a></li>
-                                            <li><a href="#">UI</a></li>
-                                            <li><a href="#">대학정보공시</a></li>
-                                            <li><a href="#">정보공개</a></li>
-                                            <li><a href="#">전화번호안내</a></li>
-                                            <li><a href="#">찾아오시는길</a></li>
+                                            <li><a href="university-overview.html">소개</a></li>
+                                            <li><a href="organization.html">조직도</a></li>
+                                            <li><a href="status.html">현황</a></li>
+                                            <li><a href="ui-guidelines.html">UI</a></li>
+                                            <li><a href="information-disclosure.html">대학정보공시</a></li>
+                                            <li><a href="public-info.html">정보공개</a></li>
+                                            <li><a href="contact-directory.html">전화번호안내</a></li>
+                                            <li><a href="directions.html">찾아오시는길</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">SDU 사회공헌</a>
+                                        <a class="mega-heading" href="social-contribution.html">SDU 사회공헌</a>
                                     </section>
                                     <section class="mega-section">
                                         <h3>사이버홍보실</h3>
                                         <ul>
-                                            <li><a href="#">보도기사</a></li>
-                                            <li><a href="#">대학 인증수상</a></li>
-                                            <li><a href="#">광고자료실</a></li>
+                                            <li><a href="press.html">보도기사</a></li>
+                                            <li><a href="awards.html">대학 인증수상</a></li>
+                                            <li><a href="media-kit.html">광고자료실</a></li>
                                         </ul>
                                     </section>
                                 </div>
@@ -76,34 +76,290 @@
                                     <section class="mega-section">
                                         <h3>입학안내</h3>
                                         <ul>
-                                            <li><a href="#">산업협력</a></li>
-                                            <li><a href="#">학교관계</a></li>
-                                            <li><a href="#">제휴협력</a></li>
+                                            <li><a href="industry-collaboration.html">산업협력</a></li>
+                                            <li><a href="school-relations.html">학교관계</a></li>
+                                            <li><a href="partnerships.html">제휴협력</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>교육원</h3>
                                         <ul>
-                                            <li><a href="#">전임교직원정보</a></li>
-                                            <li><a href="#">시간강사정보</a></li>
-                                            <li><a href="#">비전임교원(현황)</a></li>
-                                            <li><a href="#">튜터현황</a></li>
+                                            <li><a href="faculty-staff.html">전임교직원정보</a></li>
+                                            <li><a href="adjunct-faculty.html">시간강사정보</a></li>
+                                            <li><a href="non-tenure-faculty.html">비전임교원(현황)</a></li>
+                                            <li><a href="tutor-overview.html">튜터현황</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">입시자료공고</a>
+                                        <a class="mega-heading" href="admissions-bulletin.html">입시자료공고</a>
                                     </section>
                                 </div>
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>
@@ -158,7 +414,7 @@
             </div>
         </section>
 
-        <section class="section about">
+        <section id="policies" class="section about">
             <div class="container split">
                 <div class="text">
                     <h2>학사 제도 안내</h2>

--- a/adjunct-faculty.html
+++ b/adjunct-faculty.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>시간강사 정보 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">교육원</span>
+                <h1>시간강사 정보</h1>
+                <p>현장 전문가로 구성된 시간강사진을 만나보세요.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>산업별 실무 전문가 프로필 소개</li>
+                        <li>강의 분야와 담당 과목 안내</li>
+                        <li>산학 협력 기반의 교육 콘텐츠 강조</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>강사관리센터 (02-0000-1025)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>시간강사진은 최신 산업 흐름을 반영한 강의를 제공하며, 학생의 실무 역량을 강화합니다. 강사 지원 절차와 문의처도 함께 안내합니다.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/admissions-bulletin.html
+++ b/admissions-bulletin.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>입시 자료 공고 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">입학안내</span>
+                <h1>입시 자료 공고</h1>
+                <p>모집 요강, 설명회 자료 등 최신 입시 정보를 제공합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>연간 모집 일정과 전형별 요강 다운로드</li>
+                        <li>설명회 및 온라인 상담 일정 안내</li>
+                        <li>합격생 가이드와 준비 체크리스트 제공</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>입학관리팀 (02-0000-1028)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>입시 자료 공고 페이지에서 전형별 제출 서류와 주요 변경 사항을 확인하세요. 지원 전략과 합격 꿀팁도 함께 정리했습니다.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/admissions.html
+++ b/admissions.html
@@ -23,52 +23,52 @@
                                     <section class="mega-section">
                                         <h3>총장실</h3>
                                         <ul>
-                                            <li><a href="#">인사말</a></li>
+                                            <li><a href="greeting.html">인사말</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>학교법인</h3>
                                         <ul>
-                                            <li><a href="#">법인소개</a></li>
-                                            <li><a href="#">예결산공시</a></li>
-                                            <li><a href="#">기부금품</a></li>
+                                            <li><a href="foundation.html">법인소개</a></li>
+                                            <li><a href="financial-reports.html">예결산공시</a></li>
+                                            <li><a href="donations.html">기부금품</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>비전</h3>
                                         <ul>
-                                            <li><a href="#">교육이념</a></li>
-                                            <li><a href="#">SDU 대학특성화</a></li>
-                                            <li><a href="#">SDU 2025</a></li>
+                                            <li><a href="education-philosophy.html">교육이념</a></li>
+                                            <li><a href="sdu-specialization.html">SDU 대학특성화</a></li>
+                                            <li><a href="sdu-2025.html">SDU 2025</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">Why SDU</a>
+                                        <a class="mega-heading" href="why-sdu.html">Why SDU</a>
                                     </section>
                                 </div>
                                 <div class="mega-column">
                                     <section class="mega-section">
                                         <h3>대학정보</h3>
                                         <ul>
-                                            <li><a href="#">소개</a></li>
-                                            <li><a href="#">조직도</a></li>
-                                            <li><a href="#">현황</a></li>
-                                            <li><a href="#">UI</a></li>
-                                            <li><a href="#">대학정보공시</a></li>
-                                            <li><a href="#">정보공개</a></li>
-                                            <li><a href="#">전화번호안내</a></li>
-                                            <li><a href="#">찾아오시는길</a></li>
+                                            <li><a href="university-overview.html">소개</a></li>
+                                            <li><a href="organization.html">조직도</a></li>
+                                            <li><a href="status.html">현황</a></li>
+                                            <li><a href="ui-guidelines.html">UI</a></li>
+                                            <li><a href="information-disclosure.html">대학정보공시</a></li>
+                                            <li><a href="public-info.html">정보공개</a></li>
+                                            <li><a href="contact-directory.html">전화번호안내</a></li>
+                                            <li><a href="directions.html">찾아오시는길</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">SDU 사회공헌</a>
+                                        <a class="mega-heading" href="social-contribution.html">SDU 사회공헌</a>
                                     </section>
                                     <section class="mega-section">
                                         <h3>사이버홍보실</h3>
                                         <ul>
-                                            <li><a href="#">보도기사</a></li>
-                                            <li><a href="#">대학 인증수상</a></li>
-                                            <li><a href="#">광고자료실</a></li>
+                                            <li><a href="press.html">보도기사</a></li>
+                                            <li><a href="awards.html">대학 인증수상</a></li>
+                                            <li><a href="media-kit.html">광고자료실</a></li>
                                         </ul>
                                     </section>
                                 </div>
@@ -76,34 +76,290 @@
                                     <section class="mega-section">
                                         <h3>입학안내</h3>
                                         <ul>
-                                            <li><a href="#">산업협력</a></li>
-                                            <li><a href="#">학교관계</a></li>
-                                            <li><a href="#">제휴협력</a></li>
+                                            <li><a href="industry-collaboration.html">산업협력</a></li>
+                                            <li><a href="school-relations.html">학교관계</a></li>
+                                            <li><a href="partnerships.html">제휴협력</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>교육원</h3>
                                         <ul>
-                                            <li><a href="#">전임교직원정보</a></li>
-                                            <li><a href="#">시간강사정보</a></li>
-                                            <li><a href="#">비전임교원(현황)</a></li>
-                                            <li><a href="#">튜터현황</a></li>
+                                            <li><a href="faculty-staff.html">전임교직원정보</a></li>
+                                            <li><a href="adjunct-faculty.html">시간강사정보</a></li>
+                                            <li><a href="non-tenure-faculty.html">비전임교원(현황)</a></li>
+                                            <li><a href="tutor-overview.html">튜터현황</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">입시자료공고</a>
+                                        <a class="mega-heading" href="admissions-bulletin.html">입시자료공고</a>
                                     </section>
                                 </div>
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -103,36 +103,27 @@ img {
 }
 
 .main-nav li.has-mega > a {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.3rem;
+    display: inline-block;
 }
 
 .main-nav li.has-mega > a::after {
     display: none;
 }
 
-.has-mega > a::before {
+.has-mega::after {
     content: "";
-    display: inline-block;
-    width: 0.5rem;
-    height: 0.5rem;
-    border-right: 2px solid currentColor;
-    border-bottom: 2px solid currentColor;
-    transform: rotate(45deg);
-    margin-left: 0.25rem;
-    transition: transform 0.2s ease;
-}
-
-.has-mega:hover > a::before,
-.has-mega:focus-within > a::before {
-    transform: rotate(225deg);
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 100%;
+    height: 1.25rem;
+    pointer-events: none;
 }
 
 .mega-menu {
     position: absolute;
     left: 50%;
-    top: calc(100% + 1rem);
+    top: 100%;
     transform: translate(-50%, 10px);
     width: min(920px, 90vw);
     background: #0f1f4c;
@@ -206,6 +197,110 @@ img {
 .mega-heading::after {
     content: "→";
     font-size: 0.8rem;
+}
+
+.content-page {
+    background: var(--white);
+}
+
+.page-hero {
+    padding: 6rem 0 3rem;
+    background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+    color: var(--white);
+}
+
+.page-hero .container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.page-category {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.35rem 0.8rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.18);
+    font-size: 0.85rem;
+    letter-spacing: 0.02em;
+}
+
+.page-body {
+    padding: 3.5rem 0;
+    background: var(--bg);
+}
+
+.page-body .container {
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    align-items: start;
+}
+
+.info-block,
+.info-aside {
+    background: var(--white);
+    border-radius: 1.25rem;
+    padding: 2.25rem;
+    box-shadow: 0 20px 45px rgba(17, 29, 63, 0.08);
+}
+
+.info-block h2 {
+    margin-top: 0;
+    font-size: 1.75rem;
+}
+
+.info-list {
+    margin: 1.5rem 0 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: 0.75rem;
+    list-style: disc;
+}
+
+.info-list li {
+    color: var(--muted);
+    font-weight: 500;
+}
+
+.info-aside {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.info-aside h3 {
+    margin: 0;
+    font-size: 1.25rem;
+}
+
+.info-aside__time {
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.info-aside .btn {
+    text-align: center;
+}
+
+.page-detail {
+    padding: 3rem 0 5rem;
+}
+
+.page-detail .container {
+    max-width: 860px;
+}
+
+.page-detail h2 {
+    font-size: 1.75rem;
+    margin-bottom: 1rem;
+}
+
+.page-detail p {
+    color: var(--muted);
+    font-size: 1.05rem;
+    line-height: 1.8;
 }
 
 .cta-group {
@@ -618,5 +713,18 @@ img {
     .footer-bottom {
         flex-direction: column;
         align-items: flex-start;
+    }
+
+    .page-body .container {
+        grid-template-columns: 1fr;
+    }
+
+    .info-block,
+    .info-aside {
+        padding: 1.75rem;
+    }
+
+    .page-hero {
+        padding: 4rem 0 2.5rem;
     }
 }

--- a/awards.html
+++ b/awards.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>대학 인증·수상 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">사이버홍보실</span>
+                <h1>대학 인증·수상</h1>
+                <p>서울 사이버 캠퍼스가 받은 주요 인증과 수상 내역을 소개합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>국내외 교육기관 인증 현황</li>
+                        <li>최근 5년간 수상 실적 정리</li>
+                        <li>인증·수상과 연계된 교육 품질 개선 사례</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>품질관리센터 (02-0000-1019)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>대학 인증과 수상은 교육 품질과 혁신 역량을 보여주는 지표입니다. 각 인증의 의미와 학생에게 제공되는 혜택을 자세히 살펴보세요.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/campus-life.html
+++ b/campus-life.html
@@ -23,52 +23,52 @@
                                     <section class="mega-section">
                                         <h3>총장실</h3>
                                         <ul>
-                                            <li><a href="#">인사말</a></li>
+                                            <li><a href="greeting.html">인사말</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>학교법인</h3>
                                         <ul>
-                                            <li><a href="#">법인소개</a></li>
-                                            <li><a href="#">예결산공시</a></li>
-                                            <li><a href="#">기부금품</a></li>
+                                            <li><a href="foundation.html">법인소개</a></li>
+                                            <li><a href="financial-reports.html">예결산공시</a></li>
+                                            <li><a href="donations.html">기부금품</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>비전</h3>
                                         <ul>
-                                            <li><a href="#">교육이념</a></li>
-                                            <li><a href="#">SDU 대학특성화</a></li>
-                                            <li><a href="#">SDU 2025</a></li>
+                                            <li><a href="education-philosophy.html">교육이념</a></li>
+                                            <li><a href="sdu-specialization.html">SDU 대학특성화</a></li>
+                                            <li><a href="sdu-2025.html">SDU 2025</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">Why SDU</a>
+                                        <a class="mega-heading" href="why-sdu.html">Why SDU</a>
                                     </section>
                                 </div>
                                 <div class="mega-column">
                                     <section class="mega-section">
                                         <h3>대학정보</h3>
                                         <ul>
-                                            <li><a href="#">소개</a></li>
-                                            <li><a href="#">조직도</a></li>
-                                            <li><a href="#">현황</a></li>
-                                            <li><a href="#">UI</a></li>
-                                            <li><a href="#">대학정보공시</a></li>
-                                            <li><a href="#">정보공개</a></li>
-                                            <li><a href="#">전화번호안내</a></li>
-                                            <li><a href="#">찾아오시는길</a></li>
+                                            <li><a href="university-overview.html">소개</a></li>
+                                            <li><a href="organization.html">조직도</a></li>
+                                            <li><a href="status.html">현황</a></li>
+                                            <li><a href="ui-guidelines.html">UI</a></li>
+                                            <li><a href="information-disclosure.html">대학정보공시</a></li>
+                                            <li><a href="public-info.html">정보공개</a></li>
+                                            <li><a href="contact-directory.html">전화번호안내</a></li>
+                                            <li><a href="directions.html">찾아오시는길</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">SDU 사회공헌</a>
+                                        <a class="mega-heading" href="social-contribution.html">SDU 사회공헌</a>
                                     </section>
                                     <section class="mega-section">
                                         <h3>사이버홍보실</h3>
                                         <ul>
-                                            <li><a href="#">보도기사</a></li>
-                                            <li><a href="#">대학 인증수상</a></li>
-                                            <li><a href="#">광고자료실</a></li>
+                                            <li><a href="press.html">보도기사</a></li>
+                                            <li><a href="awards.html">대학 인증수상</a></li>
+                                            <li><a href="media-kit.html">광고자료실</a></li>
                                         </ul>
                                     </section>
                                 </div>
@@ -76,34 +76,290 @@
                                     <section class="mega-section">
                                         <h3>입학안내</h3>
                                         <ul>
-                                            <li><a href="#">산업협력</a></li>
-                                            <li><a href="#">학교관계</a></li>
-                                            <li><a href="#">제휴협력</a></li>
+                                            <li><a href="industry-collaboration.html">산업협력</a></li>
+                                            <li><a href="school-relations.html">학교관계</a></li>
+                                            <li><a href="partnerships.html">제휴협력</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>교육원</h3>
                                         <ul>
-                                            <li><a href="#">전임교직원정보</a></li>
-                                            <li><a href="#">시간강사정보</a></li>
-                                            <li><a href="#">비전임교원(현황)</a></li>
-                                            <li><a href="#">튜터현황</a></li>
+                                            <li><a href="faculty-staff.html">전임교직원정보</a></li>
+                                            <li><a href="adjunct-faculty.html">시간강사정보</a></li>
+                                            <li><a href="non-tenure-faculty.html">비전임교원(현황)</a></li>
+                                            <li><a href="tutor-overview.html">튜터현황</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">입시자료공고</a>
+                                        <a class="mega-heading" href="admissions-bulletin.html">입시자료공고</a>
                                     </section>
                                 </div>
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>
@@ -162,7 +418,7 @@
             </div>
         </section>
 
-        <section class="section about">
+        <section id="experience" class="section about">
             <div class="container split">
                 <div class="text">
                     <h2>학생 경험 지원</h2>

--- a/contact-directory.html
+++ b/contact-directory.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>전화번호 안내 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">대학정보</span>
+                <h1>전화번호 안내</h1>
+                <p>주요 부서의 연락처와 상담 채널을 한눈에 제공합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>학사, 입학, 학생지원 등 주요 부서 연락처 정리</li>
+                        <li>응급 상황 및 야간 상담 채널 안내</li>
+                        <li>온라인 문의 및 상담 예약 방법 소개</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>고객센터 (02-0000-1015)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>전화번호 안내 페이지는 필요한 지원 부서를 빠르게 찾을 수 있도록 구성되었습니다. 분야별 담당자 정보를 확인하고 바로 연락해 보세요.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/convergence.html
+++ b/convergence.html
@@ -23,52 +23,52 @@
                                     <section class="mega-section">
                                         <h3>총장실</h3>
                                         <ul>
-                                            <li><a href="#">인사말</a></li>
+                                            <li><a href="greeting.html">인사말</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>학교법인</h3>
                                         <ul>
-                                            <li><a href="#">법인소개</a></li>
-                                            <li><a href="#">예결산공시</a></li>
-                                            <li><a href="#">기부금품</a></li>
+                                            <li><a href="foundation.html">법인소개</a></li>
+                                            <li><a href="financial-reports.html">예결산공시</a></li>
+                                            <li><a href="donations.html">기부금품</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>비전</h3>
                                         <ul>
-                                            <li><a href="#">교육이념</a></li>
-                                            <li><a href="#">SDU 대학특성화</a></li>
-                                            <li><a href="#">SDU 2025</a></li>
+                                            <li><a href="education-philosophy.html">교육이념</a></li>
+                                            <li><a href="sdu-specialization.html">SDU 대학특성화</a></li>
+                                            <li><a href="sdu-2025.html">SDU 2025</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">Why SDU</a>
+                                        <a class="mega-heading" href="why-sdu.html">Why SDU</a>
                                     </section>
                                 </div>
                                 <div class="mega-column">
                                     <section class="mega-section">
                                         <h3>대학정보</h3>
                                         <ul>
-                                            <li><a href="#">소개</a></li>
-                                            <li><a href="#">조직도</a></li>
-                                            <li><a href="#">현황</a></li>
-                                            <li><a href="#">UI</a></li>
-                                            <li><a href="#">대학정보공시</a></li>
-                                            <li><a href="#">정보공개</a></li>
-                                            <li><a href="#">전화번호안내</a></li>
-                                            <li><a href="#">찾아오시는길</a></li>
+                                            <li><a href="university-overview.html">소개</a></li>
+                                            <li><a href="organization.html">조직도</a></li>
+                                            <li><a href="status.html">현황</a></li>
+                                            <li><a href="ui-guidelines.html">UI</a></li>
+                                            <li><a href="information-disclosure.html">대학정보공시</a></li>
+                                            <li><a href="public-info.html">정보공개</a></li>
+                                            <li><a href="contact-directory.html">전화번호안내</a></li>
+                                            <li><a href="directions.html">찾아오시는길</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">SDU 사회공헌</a>
+                                        <a class="mega-heading" href="social-contribution.html">SDU 사회공헌</a>
                                     </section>
                                     <section class="mega-section">
                                         <h3>사이버홍보실</h3>
                                         <ul>
-                                            <li><a href="#">보도기사</a></li>
-                                            <li><a href="#">대학 인증수상</a></li>
-                                            <li><a href="#">광고자료실</a></li>
+                                            <li><a href="press.html">보도기사</a></li>
+                                            <li><a href="awards.html">대학 인증수상</a></li>
+                                            <li><a href="media-kit.html">광고자료실</a></li>
                                         </ul>
                                     </section>
                                 </div>
@@ -76,34 +76,290 @@
                                     <section class="mega-section">
                                         <h3>입학안내</h3>
                                         <ul>
-                                            <li><a href="#">산업협력</a></li>
-                                            <li><a href="#">학교관계</a></li>
-                                            <li><a href="#">제휴협력</a></li>
+                                            <li><a href="industry-collaboration.html">산업협력</a></li>
+                                            <li><a href="school-relations.html">학교관계</a></li>
+                                            <li><a href="partnerships.html">제휴협력</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>교육원</h3>
                                         <ul>
-                                            <li><a href="#">전임교직원정보</a></li>
-                                            <li><a href="#">시간강사정보</a></li>
-                                            <li><a href="#">비전임교원(현황)</a></li>
-                                            <li><a href="#">튜터현황</a></li>
+                                            <li><a href="faculty-staff.html">전임교직원정보</a></li>
+                                            <li><a href="adjunct-faculty.html">시간강사정보</a></li>
+                                            <li><a href="non-tenure-faculty.html">비전임교원(현황)</a></li>
+                                            <li><a href="tutor-overview.html">튜터현황</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">입시자료공고</a>
+                                        <a class="mega-heading" href="admissions-bulletin.html">입시자료공고</a>
                                     </section>
                                 </div>
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>
@@ -157,7 +413,7 @@
             </div>
         </section>
 
-        <section class="section about">
+        <section id="projects" class="section about">
             <div class="container split">
                 <div class="text">
                     <h2>산업체 연계 프로젝트</h2>

--- a/directions.html
+++ b/directions.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>찾아오시는 길 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">대학정보</span>
+                <h1>찾아오시는 길</h1>
+                <p>서울 사이버 캠퍼스 방문을 위한 교통 정보를 제공합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>지하철·버스 등 대중교통 안내</li>
+                        <li>자가용 방문 시 주차 정보 제공</li>
+                        <li>온라인 캠퍼스 투어 영상 연결</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>시설관리팀 (02-0000-1016)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>캠퍼스 방문 전 위치와 주차, 셔틀버스 운행 정보를 확인하세요. 온라인으로도 캠퍼스를 둘러볼 수 있는 자료를 함께 제공합니다.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/donations.html
+++ b/donations.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>기부금품 안내 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">학교법인</span>
+                <h1>기부금품 안내</h1>
+                <p>기부금 모금 현황과 활용 사례를 안내합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>기부 캠페인과 참여 방법 소개</li>
+                        <li>기부금 사용 내역과 성과 공유</li>
+                        <li>기부자 예우 프로그램 및 혜택 안내</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>대외협력팀 (02-0000-1004)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>여러분의 소중한 기부는 학생 장학금, 교육 시설 개선, 지역사회 공헌 사업에 활용됩니다. 기부금 투명 관리 체계와 감사 보고서를 이곳에서 확인하세요.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/education-philosophy.html
+++ b/education-philosophy.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>교육이념 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">비전</span>
+                <h1>교육이념</h1>
+                <p>서울 사이버 캠퍼스가 추구하는 교육 이념과 핵심 가치를 소개합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>학생 중심의 맞춤형 학습 경험 제공</li>
+                        <li>디지털 역량을 강화하는 실무 중심 교육</li>
+                        <li>평생 교육을 지원하는 열린 캠퍼스 구현</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>교육혁신센터 (02-0000-1005)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>서울 사이버 캠퍼스는 언제 어디서나 학습할 수 있는 환경을 통해 학생이 주도적으로 성장할 수 있도록 지원합니다. 교육이념을 토대로 다양한 학사제도와 학습지원 프로그램이 운영됩니다.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/faculty-staff.html
+++ b/faculty-staff.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>전임교직원 정보 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">교육원</span>
+                <h1>전임교직원 정보</h1>
+                <p>전임 교수진과 교직원의 전문 분야를 소개합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>학과별 전임교수 프로필과 연구 분야</li>
+                        <li>학생 지원을 담당하는 행정 직원 안내</li>
+                        <li>대표 강의 및 연구 성과 소개</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>교무처 (02-0000-1024)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>전임교직원 정보는 학문적 전문성과 교육 열정을 갖춘 교수진을 소개합니다. 연구 실적과 주요 강의 정보를 확인할 수 있습니다.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/financial-reports.html
+++ b/financial-reports.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>예결산 공시 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">학교법인</span>
+                <h1>예결산 공시</h1>
+                <p>연도별 예산과 결산 내역을 투명하게 공개합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>연간 예산 편성 및 집행 현황 공개</li>
+                        <li>재정 건전성 지표 및 개선 전략 안내</li>
+                        <li>주요 투자 및 지원 사업에 대한 상세 보고</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>재무회계팀 (02-0000-1003)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>서울 사이버 캠퍼스는 공공성과 투명성을 지키기 위해 정기적으로 재무 정보를 공개합니다. 예산 계획과 결산 결과를 비교하여 재정 운영의 효율성을 확인할 수 있습니다.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/foundation.html
+++ b/foundation.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>학교법인 소개 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">학교법인</span>
+                <h1>학교법인 소개</h1>
+                <p>서울 사이버 캠퍼스를 운영하는 학교법인의 비전과 조직을 소개합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>법인 설립 목적과 운영 원칙 안내</li>
+                        <li>투명한 거버넌스 구조와 의사결정 체계 설명</li>
+                        <li>사회와 함께 성장하는 공익적 활동 소개</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>법인사무국 (02-0000-1002)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>학교법인은 혁신적인 사이버 교육 환경을 구축하기 위해 다양한 전략과 지원을 펼치고 있습니다. 주요 사업과 추진 성과, 그리고 대학 구성원과의 협력 구조를 자세히 알아보세요.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/greeting.html
+++ b/greeting.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>총장 인사말 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">총장실</span>
+                <h1>총장 인사말</h1>
+                <p>서울 사이버 캠퍼스 총장의 환영 메시지와 교육 철학을 만나보세요.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>대학이 추구하는 핵심 가치와 미래 비전 공유</li>
+                        <li>학생과 교수진이 함께 만들어가는 학습 문화 소개</li>
+                        <li>사회적 책임을 실천하는 서울 사이버 캠퍼스의 방향 제시</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>총장실 (02-0000-1001)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>총장실에서는 구성원 모두가 공감할 수 있는 목표와 약속을 전하고 있습니다. 본 페이지에서 학교가 추구하는 교육철학과 더불어 학생에게 제공되는 다양한 성장 기회를 확인할 수 있습니다.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/index.html
+++ b/index.html
@@ -23,52 +23,52 @@
                                     <section class="mega-section">
                                         <h3>총장실</h3>
                                         <ul>
-                                            <li><a href="#">인사말</a></li>
+                                            <li><a href="greeting.html">인사말</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>학교법인</h3>
                                         <ul>
-                                            <li><a href="#">법인소개</a></li>
-                                            <li><a href="#">예결산공시</a></li>
-                                            <li><a href="#">기부금품</a></li>
+                                            <li><a href="foundation.html">법인소개</a></li>
+                                            <li><a href="financial-reports.html">예결산공시</a></li>
+                                            <li><a href="donations.html">기부금품</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>비전</h3>
                                         <ul>
-                                            <li><a href="#">교육이념</a></li>
-                                            <li><a href="#">SDU 대학특성화</a></li>
-                                            <li><a href="#">SDU 2025</a></li>
+                                            <li><a href="education-philosophy.html">교육이념</a></li>
+                                            <li><a href="sdu-specialization.html">SDU 대학특성화</a></li>
+                                            <li><a href="sdu-2025.html">SDU 2025</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">Why SDU</a>
+                                        <a class="mega-heading" href="why-sdu.html">Why SDU</a>
                                     </section>
                                 </div>
                                 <div class="mega-column">
                                     <section class="mega-section">
                                         <h3>대학정보</h3>
                                         <ul>
-                                            <li><a href="#">소개</a></li>
-                                            <li><a href="#">조직도</a></li>
-                                            <li><a href="#">현황</a></li>
-                                            <li><a href="#">UI</a></li>
-                                            <li><a href="#">대학정보공시</a></li>
-                                            <li><a href="#">정보공개</a></li>
-                                            <li><a href="#">전화번호안내</a></li>
-                                            <li><a href="#">찾아오시는길</a></li>
+                                            <li><a href="university-overview.html">소개</a></li>
+                                            <li><a href="organization.html">조직도</a></li>
+                                            <li><a href="status.html">현황</a></li>
+                                            <li><a href="ui-guidelines.html">UI</a></li>
+                                            <li><a href="information-disclosure.html">대학정보공시</a></li>
+                                            <li><a href="public-info.html">정보공개</a></li>
+                                            <li><a href="contact-directory.html">전화번호안내</a></li>
+                                            <li><a href="directions.html">찾아오시는길</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">SDU 사회공헌</a>
+                                        <a class="mega-heading" href="social-contribution.html">SDU 사회공헌</a>
                                     </section>
                                     <section class="mega-section">
                                         <h3>사이버홍보실</h3>
                                         <ul>
-                                            <li><a href="#">보도기사</a></li>
-                                            <li><a href="#">대학 인증수상</a></li>
-                                            <li><a href="#">광고자료실</a></li>
+                                            <li><a href="press.html">보도기사</a></li>
+                                            <li><a href="awards.html">대학 인증수상</a></li>
+                                            <li><a href="media-kit.html">광고자료실</a></li>
                                         </ul>
                                     </section>
                                 </div>
@@ -76,34 +76,290 @@
                                     <section class="mega-section">
                                         <h3>입학안내</h3>
                                         <ul>
-                                            <li><a href="#">산업협력</a></li>
-                                            <li><a href="#">학교관계</a></li>
-                                            <li><a href="#">제휴협력</a></li>
+                                            <li><a href="industry-collaboration.html">산업협력</a></li>
+                                            <li><a href="school-relations.html">학교관계</a></li>
+                                            <li><a href="partnerships.html">제휴협력</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>교육원</h3>
                                         <ul>
-                                            <li><a href="#">전임교직원정보</a></li>
-                                            <li><a href="#">시간강사정보</a></li>
-                                            <li><a href="#">비전임교원(현황)</a></li>
-                                            <li><a href="#">튜터현황</a></li>
+                                            <li><a href="faculty-staff.html">전임교직원정보</a></li>
+                                            <li><a href="adjunct-faculty.html">시간강사정보</a></li>
+                                            <li><a href="non-tenure-faculty.html">비전임교원(현황)</a></li>
+                                            <li><a href="tutor-overview.html">튜터현황</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">입시자료공고</a>
+                                        <a class="mega-heading" href="admissions-bulletin.html">입시자료공고</a>
                                     </section>
                                 </div>
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>

--- a/industry-collaboration.html
+++ b/industry-collaboration.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>산업협력 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">입학안내</span>
+                <h1>산업협력</h1>
+                <p>산업체와 함께하는 맞춤형 교육 및 협력 프로그램을 소개합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>기업 연계 산학 프로젝트 안내</li>
+                        <li>현장 실습 및 인턴십 기회 제공</li>
+                        <li>공동 연구 및 기술 교류 사례 공유</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>산학협력단 (02-0000-1021)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>산업협력 프로그램을 통해 학생들은 실무 경험을 쌓고 최신 산업 동향을 학습합니다. 기업과의 협업을 통한 커리큘럼 혁신 사례도 확인해 보세요.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/information-disclosure.html
+++ b/information-disclosure.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>대학정보공시 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">대학정보</span>
+                <h1>대학정보공시</h1>
+                <p>관련 법령에 따라 공개되는 대학 정보 공시 자료를 확인하세요.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>대학 기본 현황 및 교육 여건 지표 공개</li>
+                        <li>재정·복지·학생지원 관련 통계 제공</li>
+                        <li>자료 다운로드 및 열람 방법 안내</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>대학정보공시 담당 (02-0000-1013)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>대학정보공시는 학생과 학부모, 사회가 학교를 신뢰할 수 있도록 돕는 중요한 자료입니다. 최신 공시 자료와 관련 링크를 정리했습니다.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/media-kit.html
+++ b/media-kit.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>광고자료실 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">사이버홍보실</span>
+                <h1>광고자료실</h1>
+                <p>대학 홍보를 위한 이미지, 영상, 인쇄물을 다운로드할 수 있습니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>로고 및 브랜드 자료 패키지 제공</li>
+                        <li>홍보 영상과 브로슈어 다운로드</li>
+                        <li>사용 가이드와 저작권 안내 포함</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>콘텐츠제작팀 (02-0000-1020)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>광고자료실에서는 외부 홍보를 위한 공식 자료를 제공합니다. 활용 시 반드시 가이드라인을 확인하고 출처를 명시해 주세요.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/news.html
+++ b/news.html
@@ -23,52 +23,52 @@
                                     <section class="mega-section">
                                         <h3>총장실</h3>
                                         <ul>
-                                            <li><a href="#">인사말</a></li>
+                                            <li><a href="greeting.html">인사말</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>학교법인</h3>
                                         <ul>
-                                            <li><a href="#">법인소개</a></li>
-                                            <li><a href="#">예결산공시</a></li>
-                                            <li><a href="#">기부금품</a></li>
+                                            <li><a href="foundation.html">법인소개</a></li>
+                                            <li><a href="financial-reports.html">예결산공시</a></li>
+                                            <li><a href="donations.html">기부금품</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>비전</h3>
                                         <ul>
-                                            <li><a href="#">교육이념</a></li>
-                                            <li><a href="#">SDU 대학특성화</a></li>
-                                            <li><a href="#">SDU 2025</a></li>
+                                            <li><a href="education-philosophy.html">교육이념</a></li>
+                                            <li><a href="sdu-specialization.html">SDU 대학특성화</a></li>
+                                            <li><a href="sdu-2025.html">SDU 2025</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">Why SDU</a>
+                                        <a class="mega-heading" href="why-sdu.html">Why SDU</a>
                                     </section>
                                 </div>
                                 <div class="mega-column">
                                     <section class="mega-section">
                                         <h3>대학정보</h3>
                                         <ul>
-                                            <li><a href="#">소개</a></li>
-                                            <li><a href="#">조직도</a></li>
-                                            <li><a href="#">현황</a></li>
-                                            <li><a href="#">UI</a></li>
-                                            <li><a href="#">대학정보공시</a></li>
-                                            <li><a href="#">정보공개</a></li>
-                                            <li><a href="#">전화번호안내</a></li>
-                                            <li><a href="#">찾아오시는길</a></li>
+                                            <li><a href="university-overview.html">소개</a></li>
+                                            <li><a href="organization.html">조직도</a></li>
+                                            <li><a href="status.html">현황</a></li>
+                                            <li><a href="ui-guidelines.html">UI</a></li>
+                                            <li><a href="information-disclosure.html">대학정보공시</a></li>
+                                            <li><a href="public-info.html">정보공개</a></li>
+                                            <li><a href="contact-directory.html">전화번호안내</a></li>
+                                            <li><a href="directions.html">찾아오시는길</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">SDU 사회공헌</a>
+                                        <a class="mega-heading" href="social-contribution.html">SDU 사회공헌</a>
                                     </section>
                                     <section class="mega-section">
                                         <h3>사이버홍보실</h3>
                                         <ul>
-                                            <li><a href="#">보도기사</a></li>
-                                            <li><a href="#">대학 인증수상</a></li>
-                                            <li><a href="#">광고자료실</a></li>
+                                            <li><a href="press.html">보도기사</a></li>
+                                            <li><a href="awards.html">대학 인증수상</a></li>
+                                            <li><a href="media-kit.html">광고자료실</a></li>
                                         </ul>
                                     </section>
                                 </div>
@@ -76,34 +76,290 @@
                                     <section class="mega-section">
                                         <h3>입학안내</h3>
                                         <ul>
-                                            <li><a href="#">산업협력</a></li>
-                                            <li><a href="#">학교관계</a></li>
-                                            <li><a href="#">제휴협력</a></li>
+                                            <li><a href="industry-collaboration.html">산업협력</a></li>
+                                            <li><a href="school-relations.html">학교관계</a></li>
+                                            <li><a href="partnerships.html">제휴협력</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>교육원</h3>
                                         <ul>
-                                            <li><a href="#">전임교직원정보</a></li>
-                                            <li><a href="#">시간강사정보</a></li>
-                                            <li><a href="#">비전임교원(현황)</a></li>
-                                            <li><a href="#">튜터현황</a></li>
+                                            <li><a href="faculty-staff.html">전임교직원정보</a></li>
+                                            <li><a href="adjunct-faculty.html">시간강사정보</a></li>
+                                            <li><a href="non-tenure-faculty.html">비전임교원(현황)</a></li>
+                                            <li><a href="tutor-overview.html">튜터현황</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">입시자료공고</a>
+                                        <a class="mega-heading" href="admissions-bulletin.html">입시자료공고</a>
                                     </section>
                                 </div>
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>

--- a/non-tenure-faculty.html
+++ b/non-tenure-faculty.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>비전임교원 현황 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">교육원</span>
+                <h1>비전임교원 현황</h1>
+                <p>비전임 교원의 구성과 운영 현황을 안내합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>비전임 교원 구성 비율 및 담당 과목</li>
+                        <li>교육 품질 관리를 위한 지원 제도</li>
+                        <li>교원 역량 개발 프로그램 소개</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>교원인사팀 (02-0000-1026)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>비전임 교원은 다양한 분야의 전문가로서 교육과 연구를 지원합니다. 선발 기준과 역량 개발 지원 프로그램을 확인해 보세요.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/organization.html
+++ b/organization.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>조직도 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">대학정보</span>
+                <h1>조직도</h1>
+                <p>대학의 조직 구성과 각 부서의 역할을 안내합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>대학 본부, 단과대학, 연구소 조직 구조 소개</li>
+                        <li>주요 부서별 업무와 연락처 제공</li>
+                        <li>의사결정 체계와 협업 흐름 안내</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>총무인사팀 (02-0000-1010)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>조직도 페이지에서는 대학의 효율적인 운영을 위한 조직 구조를 확인할 수 있습니다. 부서별 역할과 협력 관계를 이해하면 필요한 지원을 더 빠르게 받을 수 있습니다.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/partnerships.html
+++ b/partnerships.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>제휴협력 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">입학안내</span>
+                <h1>제휴협력</h1>
+                <p>국내외 기관과의 제휴 프로그램 및 혜택을 안내합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>해외 대학 및 교육기관과의 교류 소개</li>
+                        <li>산업체 파트너십으로 제공되는 장학 혜택</li>
+                        <li>재직자 맞춤형 온라인 교육 솔루션</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>대외협력실 (02-0000-1023)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>제휴협력은 학생에게 폭넓은 학습 기회를 제공하고, 기업과 기관에는 맞춤형 교육을 지원합니다. 주요 협약 현황과 신청 절차를 확인하세요.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/press.html
+++ b/press.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>보도기사 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">사이버홍보실</span>
+                <h1>보도기사</h1>
+                <p>언론에 소개된 서울 사이버 캠퍼스의 최신 소식을 모았습니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>언론 보도와 인터뷰 기사 모음</li>
+                        <li>주요 보도자료 다운로드 제공</li>
+                        <li>대외 평가 및 수상 소식 공유</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>홍보팀 (02-0000-1018)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>언론에 소개된 다양한 소식을 통해 학교의 변화와 성장을 확인하세요. 분야별 기사 분류와 검색 기능을 통해 원하는 정보를 빠르게 찾을 수 있습니다.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/public-info.html
+++ b/public-info.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>정보공개 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">대학정보</span>
+                <h1>정보공개</h1>
+                <p>정보공개 청구 절차와 처리 현황을 안내합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>정보공개 청구 방법 및 기한 안내</li>
+                        <li>처리 절차와 불복 구제 제도 설명</li>
+                        <li>자주 요청되는 공개 자료 모음 제공</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>정보공개센터 (02-0000-1014)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>정보공개 제도를 통해 서울 사이버 캠퍼스의 행정 정보를 투명하게 확인할 수 있습니다. 청구 방법과 문의 창구를 상세히 안내합니다.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/school-relations.html
+++ b/school-relations.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>학교관계 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">입학안내</span>
+                <h1>학교관계</h1>
+                <p>고교·전문대학과의 연계 프로그램과 협력 모델을 안내합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>공동 교육과정 및 학점 교류 제도 소개</li>
+                        <li>입시 설명회와 진로 박람회 운영</li>
+                        <li>교사 대상 온라인 연수 프로그램 안내</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>입학사정관실 (02-0000-1022)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>학교관계 페이지에서는 중등·고등교육기관과 진행하는 다양한 협력 사업을 확인할 수 있습니다. 예비 학습자를 위한 맞춤형 프로그램도 함께 제공합니다.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/sdu-2025.html
+++ b/sdu-2025.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>SDU 2025 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">비전</span>
+                <h1>SDU 2025</h1>
+                <p>2025년을 향한 중장기 발전 계획과 핵심 과제를 공유합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>교육 혁신을 위한 디지털 인프라 고도화</li>
+                        <li>학습자 데이터 기반 맞춤 서비스 확대</li>
+                        <li>지역사회와 동반 성장하는 사회공헌 강화</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>미래전략실 (02-0000-1007)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>SDU 2025 계획은 교육 품질 향상과 구성원 만족도 제고를 목표로 하고 있습니다. 세부 추진 일정과 전략 과제를 통해 대학의 미래상을 확인하세요.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/sdu-specialization.html
+++ b/sdu-specialization.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>SDU 대학특성화 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">비전</span>
+                <h1>SDU 대학특성화</h1>
+                <p>서울 사이버 캠퍼스만의 특성화 전략과 경쟁력을 소개합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>AI·데이터 기반의 차별화된 커리큘럼</li>
+                        <li>기업과 연계한 실무형 프로젝트 운영</li>
+                        <li>글로벌 온라인 교육 네트워크 구축</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>전략기획팀 (02-0000-1006)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>특성화 전략은 학과별 전문성과 산업 수요를 연결하여 학생의 진로 경쟁력을 높이는 데 초점을 맞추고 있습니다. 프로젝트 기반 수업과 산업체 협력 프로그램을 확인해 보세요.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/social-contribution.html
+++ b/social-contribution.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>SDU 사회공헌 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">사회공헌</span>
+                <h1>SDU 사회공헌</h1>
+                <p>지역사회와 함께하는 다양한 사회공헌 프로그램을 소개합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>지역 연계 교육 봉사 활동 소개</li>
+                        <li>사회적 기업과의 협력 사례 공유</li>
+                        <li>재학생 참여형 사회공헌 프로그램 안내</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>사회공헌센터 (02-0000-1017)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>서울 사이버 캠퍼스는 교육의 사회적 책임을 실천하기 위해 다양한 공헌 활동을 진행하고 있습니다. 프로그램 참여 방법과 후기를 확인해 보세요.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/status.html
+++ b/status.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>대학 현황 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">대학정보</span>
+                <h1>대학 현황</h1>
+                <p>재학생 수, 전임교원 현황 등 주요 지표를 제공합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>학생 구성과 학과별 재적 현황 통계</li>
+                        <li>교원 및 직원 인력 현황 소개</li>
+                        <li>교육 인프라와 학습 지원 자원 안내</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>기획평가팀 (02-0000-1011)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>대학 현황은 매년 업데이트되어 학교의 규모와 성장을 객관적으로 보여줍니다. 주요 지표를 통해 서울 사이버 캠퍼스의 경쟁력을 확인하세요.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/support.html
+++ b/support.html
@@ -23,52 +23,52 @@
                                     <section class="mega-section">
                                         <h3>총장실</h3>
                                         <ul>
-                                            <li><a href="#">인사말</a></li>
+                                            <li><a href="greeting.html">인사말</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>학교법인</h3>
                                         <ul>
-                                            <li><a href="#">법인소개</a></li>
-                                            <li><a href="#">예결산공시</a></li>
-                                            <li><a href="#">기부금품</a></li>
+                                            <li><a href="foundation.html">법인소개</a></li>
+                                            <li><a href="financial-reports.html">예결산공시</a></li>
+                                            <li><a href="donations.html">기부금품</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>비전</h3>
                                         <ul>
-                                            <li><a href="#">교육이념</a></li>
-                                            <li><a href="#">SDU 대학특성화</a></li>
-                                            <li><a href="#">SDU 2025</a></li>
+                                            <li><a href="education-philosophy.html">교육이념</a></li>
+                                            <li><a href="sdu-specialization.html">SDU 대학특성화</a></li>
+                                            <li><a href="sdu-2025.html">SDU 2025</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">Why SDU</a>
+                                        <a class="mega-heading" href="why-sdu.html">Why SDU</a>
                                     </section>
                                 </div>
                                 <div class="mega-column">
                                     <section class="mega-section">
                                         <h3>대학정보</h3>
                                         <ul>
-                                            <li><a href="#">소개</a></li>
-                                            <li><a href="#">조직도</a></li>
-                                            <li><a href="#">현황</a></li>
-                                            <li><a href="#">UI</a></li>
-                                            <li><a href="#">대학정보공시</a></li>
-                                            <li><a href="#">정보공개</a></li>
-                                            <li><a href="#">전화번호안내</a></li>
-                                            <li><a href="#">찾아오시는길</a></li>
+                                            <li><a href="university-overview.html">소개</a></li>
+                                            <li><a href="organization.html">조직도</a></li>
+                                            <li><a href="status.html">현황</a></li>
+                                            <li><a href="ui-guidelines.html">UI</a></li>
+                                            <li><a href="information-disclosure.html">대학정보공시</a></li>
+                                            <li><a href="public-info.html">정보공개</a></li>
+                                            <li><a href="contact-directory.html">전화번호안내</a></li>
+                                            <li><a href="directions.html">찾아오시는길</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">SDU 사회공헌</a>
+                                        <a class="mega-heading" href="social-contribution.html">SDU 사회공헌</a>
                                     </section>
                                     <section class="mega-section">
                                         <h3>사이버홍보실</h3>
                                         <ul>
-                                            <li><a href="#">보도기사</a></li>
-                                            <li><a href="#">대학 인증수상</a></li>
-                                            <li><a href="#">광고자료실</a></li>
+                                            <li><a href="press.html">보도기사</a></li>
+                                            <li><a href="awards.html">대학 인증수상</a></li>
+                                            <li><a href="media-kit.html">광고자료실</a></li>
                                         </ul>
                                     </section>
                                 </div>
@@ -76,34 +76,290 @@
                                     <section class="mega-section">
                                         <h3>입학안내</h3>
                                         <ul>
-                                            <li><a href="#">산업협력</a></li>
-                                            <li><a href="#">학교관계</a></li>
-                                            <li><a href="#">제휴협력</a></li>
+                                            <li><a href="industry-collaboration.html">산업협력</a></li>
+                                            <li><a href="school-relations.html">학교관계</a></li>
+                                            <li><a href="partnerships.html">제휴협력</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
                                         <h3>교육원</h3>
                                         <ul>
-                                            <li><a href="#">전임교직원정보</a></li>
-                                            <li><a href="#">시간강사정보</a></li>
-                                            <li><a href="#">비전임교원(현황)</a></li>
-                                            <li><a href="#">튜터현황</a></li>
+                                            <li><a href="faculty-staff.html">전임교직원정보</a></li>
+                                            <li><a href="adjunct-faculty.html">시간강사정보</a></li>
+                                            <li><a href="non-tenure-faculty.html">비전임교원(현황)</a></li>
+                                            <li><a href="tutor-overview.html">튜터현황</a></li>
                                         </ul>
                                     </section>
                                     <section class="mega-section">
-                                        <a class="mega-heading" href="#">입시자료공고</a>
+                                        <a class="mega-heading" href="admissions-bulletin.html">입시자료공고</a>
                                     </section>
                                 </div>
                             </div>
                         </div>
                     </li>
-                    <li><a href="programs.html">학과소개</a></li>
-                    <li><a href="convergence.html">교육융합특성화 과정</a></li>
-                    <li><a href="academics.html">학사안내</a></li>
-                    <li><a href="campus-life.html">대학생활</a></li>
-                    <li><a href="support.html">학생지원</a></li>
+                    <li class="has-mega">
+                        <a href="programs.html" aria-haspopup="true">학과소개</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>AI · 데이터 사이언스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#ai">학부 소개</a></li>
+                                            <li><a href="programs.html#ai">캡스톤 프로젝트</a></li>
+                                            <li><a href="programs.html#ai">산업 협력</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>디지털 비즈니스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#business">학부 소개</a></li>
+                                            <li><a href="programs.html#business">창업 멘토링</a></li>
+                                            <li><a href="programs.html#business">데이터 마케팅</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>휴먼서비스</h3>
+                                        <ul>
+                                            <li><a href="programs.html#human">전공 안내</a></li>
+                                            <li><a href="programs.html#human">현장 실습</a></li>
+                                            <li><a href="programs.html#human">자격증 지원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>문화예술 · 디자인</h3>
+                                        <ul>
+                                            <li><a href="programs.html#design">전공 안내</a></li>
+                                            <li><a href="programs.html#design">포트폴리오 코칭</a></li>
+                                            <li><a href="programs.html#design">산학 협력전</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="programs.html#departments">전체 전공 살펴보기</a>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학생 맞춤 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                            <li><a href="support.html">온라인 상담</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="convergence.html" aria-haspopup="true">교육융합특성화 과정</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>융합 트랙</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#curriculum">스마트 러닝 디자인</a></li>
+                                            <li><a href="convergence.html#curriculum">에듀테크 개발</a></li>
+                                            <li><a href="convergence.html#curriculum">미래교육 혁신</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>프로젝트 경험</h3>
+                                        <ul>
+                                            <li><a href="convergence.html#projects">산업체 연계</a></li>
+                                            <li><a href="convergence.html#projects">포트폴리오 리뷰</a></li>
+                                            <li><a href="convergence.html#projects">협력 네트워크</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학습 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">튜터링</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">상담 신청</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>입학 & 안내</h3>
+                                        <ul>
+                                            <li><a href="admissions.html">입학 요강</a></li>
+                                            <li><a href="news.html">설명회 일정</a></li>
+                                            <li><a href="support.html#guide">등록 절차</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="convergence.html#curriculum">브로셔 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="academics.html" aria-haspopup="true">학사안내</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>주요 일정</h3>
+                                        <ul>
+                                            <li><a href="academics.html#calendar">학사 캘린더</a></li>
+                                            <li><a href="academics.html#calendar">중간 · 기말고사</a></li>
+                                            <li><a href="academics.html#calendar">계절학기</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#calendar">학사 일정표 보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>수강 · 평가</h3>
+                                        <ul>
+                                            <li><a href="academics.html#policies">수강신청 안내</a></li>
+                                            <li><a href="academics.html#policies">성적 평가</a></li>
+                                            <li><a href="academics.html#policies">졸업 요건</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>학사 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록/장학</a></li>
+                                            <li><a href="support.html#coaching">학습 상담</a></li>
+                                            <li><a href="support.html">민원 접수</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="support.html#guide">학사 규정집</a></li>
+                                            <li><a href="support.html">FAQ</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="academics.html#policies">학사 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="campus-life.html" aria-haspopup="true">대학생활</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 커뮤니티</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#community">학습 동아리</a></li>
+                                            <li><a href="campus-life.html#community">멘토링 매칭</a></li>
+                                            <li><a href="campus-life.html#community">버추얼 교환</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#community">프로그램 전체보기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>학생 경험 지원</h3>
+                                        <ul>
+                                            <li><a href="campus-life.html#experience">1:1 코칭</a></li>
+                                            <li><a href="campus-life.html#experience">오프라인 밋업</a></li>
+                                            <li><a href="campus-life.html#experience">커뮤니티 플랫폼</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>행사 안내</h3>
+                                        <ul>
+                                            <li><a href="news.html">캠퍼스 뉴스</a></li>
+                                            <li><a href="news.html">학생 인터뷰</a></li>
+                                            <li><a href="news.html">이벤트 캘린더</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>생활 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                            <li><a href="support.html#guide">장학 제도</a></li>
+                                            <li><a href="support.html">학생지원센터</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="campus-life.html#experience">행사 일정 확인</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="has-mega">
+                        <a href="support.html" aria-haspopup="true">학생지원</a>
+                        <div class="mega-menu" role="menu">
+                            <div class="mega-columns">
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>상담 프로그램</h3>
+                                        <ul>
+                                            <li><a href="support.html#coaching">학습 코칭</a></li>
+                                            <li><a href="support.html#coaching">진로 설계</a></li>
+                                            <li><a href="support.html#coaching">심리 상담</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#coaching">상담 신청하기</a>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>행정 지원</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">등록금 납부</a></li>
+                                            <li><a href="support.html#guide">장학금 안내</a></li>
+                                            <li><a href="support.html#guide">학사 민원</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <h3>자료실</h3>
+                                        <ul>
+                                            <li><a href="news.html">공지사항</a></li>
+                                            <li><a href="news.html">FAQ</a></li>
+                                            <li><a href="news.html">서식 다운로드</a></li>
+                                        </ul>
+                                    </section>
+                                </div>
+                                <div class="mega-column">
+                                    <section class="mega-section">
+                                        <h3>바로가기</h3>
+                                        <ul>
+                                            <li><a href="support.html#guide">학생 지원 안내</a></li>
+                                            <li><a href="support.html">1:1 문의</a></li>
+                                            <li><a href="admissions.html">입시 Q&amp;A</a></li>
+                                        </ul>
+                                    </section>
+                                    <section class="mega-section">
+                                        <a class="mega-heading" href="support.html#guide">지원 가이드 다운로드</a>
+                                    </section>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
                 </ul>
             </nav>
+
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
             </div>

--- a/tutor-overview.html
+++ b/tutor-overview.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>튜터 현황 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">교육원</span>
+                <h1>튜터 현황</h1>
+                <p>학생 학습을 돕는 튜터 프로그램의 운영 현황을 소개합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>과목별 튜터 구성과 지원 내용</li>
+                        <li>학습 상담 및 학습법 코칭 서비스</li>
+                        <li>튜터 모집 및 양성 프로그램 안내</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>학습지원센터 (02-0000-1027)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>튜터는 학습자의 이해를 돕고 학업 관리를 지원하는 핵심 인력입니다. 튜터 배정 방식과 이용 절차를 살펴보세요.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/ui-guidelines.html
+++ b/ui-guidelines.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>UI 가이드라인 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">대학정보</span>
+                <h1>UI 가이드라인</h1>
+                <p>서울 사이버 캠퍼스의 공식 UI 규정과 활용 예시를 제공합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>로고, 심볼마크, 전용 서체 사용 규정</li>
+                        <li>홍보물 제작을 위한 색상 및 배치 가이드</li>
+                        <li>다운로드 가능한 공식 자료 제공</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>브랜드전략팀 (02-0000-1012)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>UI 가이드라인은 대학의 일관된 이미지를 유지하기 위해 필수적으로 확인해야 합니다. 브랜드 요소와 활용 시 유의 사항을 꼼꼼히 정리했습니다.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/university-overview.html
+++ b/university-overview.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>대학 소개 | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">대학정보</span>
+                <h1>대학 소개</h1>
+                <p>서울 사이버 캠퍼스의 역사와 주요 연혁을 소개합니다.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>학교 설립 배경과 성장 과정 정리</li>
+                        <li>대표 학과 및 교육 특성 소개</li>
+                        <li>국내외 협력 네트워크와 파트너십 공유</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>대학홍보팀 (02-0000-1009)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>대학 소개 페이지에서는 서울 사이버 캠퍼스가 걸어온 발자취와 미래 방향을 살펴볼 수 있습니다. 혁신적인 온라인 학습 환경을 어떻게 구축했는지 알아보세요.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>

--- a/why-sdu.html
+++ b/why-sdu.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>Why SDU | 서울 사이버 캠퍼스</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -365,156 +365,40 @@
             </div>
         </div>
     </header>
-
-    <main>
-        <section class="hero">
+    <main class="content-page">
+        <section class="page-hero">
             <div class="container">
-                <div class="hero-text">
-                    <span class="badge">Academic Programs</span>
-                    <h1>미래 산업을 선도할 전공을 소개합니다</h1>
-                    <p>
-                        서울 사이버 캠퍼스는 산업 수요를 반영한 다양한 학부와 전공을 운영하며, 실무형 인재 양성을 목표로 합니다.
-                        최신 트렌드를 반영한 커리큘럼으로 성장의 기회를 만나보세요.
-                    </p>
-                </div>
-                <div class="hero-visual" aria-hidden="true">
-                    <div class="floating-card">
-                        <strong>전공 상담</strong>
-                        <p>전공 선택이 고민된다면?</p>
-                        <a href="support.html">학생지원으로 이동</a>
-                    </div>
-                </div>
+                <span class="page-category">비전</span>
+                <h1>Why SDU</h1>
+                <p>서울 사이버 캠퍼스를 선택해야 하는 이유를 한눈에 확인하세요.</p>
             </div>
         </section>
-
-        <section id="departments" class="section programs">
+        <section class="page-body">
             <div class="container">
-                <div class="section-heading">
-                    <h2>학부 및 전공</h2>
-                    <p>미래 산업을 선도할 다양한 학부 및 전공을 만나보세요.</p>
-                </div>
-                <div class="program-grid">
-                    <article class="program-card">
-                        <h3>AI · 데이터 사이언스</h3>
-                        <p>머신러닝, 데이터 분석, 클라우드 기반 서비스 설계 등 4차 산업 핵심 기술을 배웁니다.</p>
-                        <a href="#ai">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>디지털 비즈니스</h3>
-                        <p>디지털 마케팅, 글로벌 비즈니스 전략, 창업 실무 역량을 키울 수 있는 과정입니다.</p>
-                        <a href="#business">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>휴먼서비스</h3>
-                        <p>상담심리, 아동가족, 사회복지 등 사람을 위한 전문 서비스를 제공합니다.</p>
-                        <a href="#human">세부 전공 보기</a>
-                    </article>
-                    <article class="program-card">
-                        <h3>문화예술 · 디자인</h3>
-                        <p>콘텐츠 제작, UX/UI 디자인, 미디어 아트 등 창의성을 실현할 수 있는 교육을 제공합니다.</p>
-                        <a href="#design">세부 전공 보기</a>
-                    </article>
-                </div>
+                <article class="info-block">
+                    <h2>주요 안내</h2>
+                    <ul class="info-list">
+                        <li>유연한 학습 환경과 탄탄한 지원 체계</li>
+                        <li>취업·창업을 연계한 실무 중심 교육 과정</li>
+                        <li>재학생과 졸업생이 전하는 생생한 경험담</li>
+                    </ul>
+                </article>
+                <aside class="info-aside">
+                    <h3>문의 안내</h3>
+                    <p>입학홍보팀 (02-0000-1008)</p>
+                    <p class="info-aside__time">운영 시간: 평일 09:00 ~ 18:00</p>
+                    <a class="btn primary" href="support.html#coaching">상담 신청하기</a>
+                    <a class="btn ghost" href="support.html#guide">FAQ 바로가기</a>
+                </aside>
             </div>
         </section>
-
-        <section id="ai" class="section">
-            <div class="container split">
-                <div>
-                    <h2>AI · 데이터 사이언스 학부</h2>
-                    <p>
-                        인공지능과 데이터 기반 의사결정을 위한 핵심 기술을 학습합니다. 머신러닝 실습, 빅데이터 분석 프로젝트,
-                        클라우드 아키텍처 과정을 통해 실무 역량을 갖춘 데이터 전문가로 성장할 수 있습니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>AI 프로그래밍 및 알고리즘 심화</li>
-                        <li>데이터 시각화와 분석 실습</li>
-                        <li>산업체 연계 캡스톤 프로젝트</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="데이터 분석 대시보드">
-                    <div class="stat">
-                        <span class="number">120+</span>
-                        <span class="label">AI 산업체 협약</span>
-                    </div>
-                    <p>기업과 연계한 실무 프로젝트로 취업 경쟁력을 확보하세요.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="business" class="section">
-            <div class="container split">
-                <div>
-                    <h2>디지털 비즈니스 학부</h2>
-                    <p>
-                        글로벌 비즈니스 전략과 디지털 마케팅을 중심으로 비즈니스 혁신 역량을 강화합니다. 실시간 데이터 분석을 바탕으로
-                        한 실습 수업과 스타트업 인큐베이팅 프로그램을 제공합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>글로벌 이커머스 실습</li>
-                        <li>브랜드 전략 및 데이터 기반 마케팅</li>
-                        <li>창업 멘토링 및 투자 연계</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디지털 마케팅 분석">
-                    <div class="stat">
-                        <span class="number">85%</span>
-                        <span class="label">창업 실무 만족도</span>
-                    </div>
-                    <p>현업 전문가와 함께 실전 비즈니스 프로젝트를 수행합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="human" class="section">
-            <div class="container split">
-                <div>
-                    <h2>휴먼서비스 학부</h2>
-                    <p>
-                        상담심리와 사회복지 분야의 전문 지식을 기반으로 사람과 사회를 지원하는 전문가를 양성합니다. 실습 중심 수업과
-                        사례 연구를 통해 현장 대응 능력을 강화합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>상담 이론 및 사례 기반 훈련</li>
-                        <li>사회복지 기관과의 연계 실습</li>
-                        <li>심리평가 및 프로그램 기획 역량 강화</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="상담 장면">
-                    <div class="stat">
-                        <span class="number">1,200+</span>
-                        <span class="label">현장 실습 시간</span>
-                    </div>
-                    <p>전문 자격증 취득을 위한 실습과 멘토링을 지원합니다.</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="design" class="section">
-            <div class="container split">
-                <div>
-                    <h2>문화예술 · 디자인 학부</h2>
-                    <p>
-                        콘텐츠 제작과 디자인 사고를 결합하여 창의적 문제 해결 능력을 키웁니다. 디지털 콘텐츠 제작, UX/UI 디자인,
-                        미디어 아트 프로젝트 등을 통해 포트폴리오를 구축합니다.
-                    </p>
-                    <ul class="feature-list">
-                        <li>멀티미디어 콘텐츠 제작 스튜디오 운영</li>
-                        <li>산업체 협업 디자인 프로젝트</li>
-                        <li>국제 공모전 참여 및 피드백 세션</li>
-                    </ul>
-                </div>
-                <div class="highlight-card" role="img" aria-label="디자인 워크숍">
-                    <div class="stat">
-                        <span class="number">60+</span>
-                        <span class="label">포트폴리오 경진대회 수상</span>
-                    </div>
-                    <p>전문가 피드백과 글로벌 교류 프로그램으로 창의력을 확장하세요.</p>
-                </div>
+        <section class="page-detail">
+            <div class="container">
+                <h2>세부 내용</h2>
+                <p>Why SDU 페이지에서는 입학생이 가장 궁금해하는 학비, 장학, 커리큘럼, 학생 서비스 정보를 종합적으로 제공합니다. 다양한 성공 사례와 지원 제도도 함께 살펴보세요.</p>
             </div>
         </section>
     </main>
-
     <footer class="site-footer">
         <div class="container footer-top">
             <div>


### PR DESCRIPTION
## Summary
- add dedicated content pages for every 입학안내 mega menu link and wire the navigation across all templates to the new destinations
- introduce shared content-page styling and update the navigation to remove the dropdown chevron icons

## Testing
- not run (static HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68de0d839a648332859b0cce45498f3d