### PR TITLE
Move translation toggle into header actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,6 +363,16 @@
 
             <div class="cta-group">
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">입학지원</a>
+                <button
+                    type="button"
+                    class="btn ghost translation-toggle"
+                    data-translate-toggle
+                    data-toggle-label-en="English"
+                    data-toggle-label-ko="한국어"
+                    aria-pressed="false"
+                >
+                    English
+                </button>
             </div>
         </div>
     </header>
@@ -666,7 +676,6 @@
                     </dl>
                     <div class="cta-group">
                         <a class="btn primary" href="#apply" data-locale-en="Apply Now">입학 지원 바로가기</a>
-                        <button type="button" class="btn ghost translation-toggle" data-translate-toggle data-toggle-label-en="English" data-toggle-label-ko="한국어" aria-pressed="false">English</button>
                     </div>
                 </div>
                 <aside class="admission-card">


### PR DESCRIPTION
## Summary
- relocate the translation toggle button into the header call-to-action area next to the admissions link
- remove the duplicate toggle from the admissions section CTA

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de231f16688332b7de253c0c21e5f9