### PR TITLE
Add global translation button support and dark mode toggle

### DIFF
--- a/about.html
+++ b/about.html
@@ -357,3 +357,6 @@
                             </div>
                         </div>
                     </li>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/academics.html
+++ b/academics.html
@@ -460,5 +460,6 @@
             <p>© 2024 Seoul Cyber Campus. All rights reserved.</p>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/adjunct-faculty.html
+++ b/adjunct-faculty.html
@@ -462,5 +462,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/admissions-bulletin.html
+++ b/admissions-bulletin.html
@@ -465,5 +465,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/admissions.html
+++ b/admissions.html
@@ -508,5 +508,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -10,6 +10,66 @@
     font-family: 'Noto Sans KR', sans-serif;
 }
 
+body.theme-dark {
+    --primary: #8596ff;
+    --primary-dark: #5064e0;
+    --accent: #ffd166;
+    --text: #e6ecff;
+    --muted: #a5b4d6;
+    --bg: #0b1120;
+    --white: #131d35;
+    --border: rgba(133, 150, 210, 0.35);
+    background: var(--bg);
+    color: var(--text);
+}
+
+body.theme-dark a:hover,
+body.theme-dark a:focus {
+    color: var(--primary);
+}
+
+body.theme-dark .site-header {
+    box-shadow: 0 12px 32px rgba(3, 8, 24, 0.7);
+}
+
+body.theme-dark .mega-menu {
+    box-shadow: 0 32px 56px rgba(4, 10, 32, 0.75);
+}
+
+body.theme-dark .hero {
+    --hero-background: radial-gradient(circle at top left, rgba(133, 150, 255, 0.18), transparent 60%),
+        linear-gradient(135deg, #0f1c3d 0%, #050b1e 70%) !important;
+    --hero-text-color: #e6ecff;
+    --hero-body-color: rgba(230, 236, 255, 0.7);
+}
+
+body.theme-dark .quick-item,
+body.theme-dark .highlight-card,
+body.theme-dark .news-card,
+body.theme-dark .guide-card,
+body.theme-dark .stat-card,
+body.theme-dark .resource-card,
+body.theme-dark .detail-card,
+body.theme-dark .program-card,
+body.theme-dark .support-card,
+body.theme-dark .contact-card,
+body.theme-dark .info-card {
+    box-shadow: 0 20px 40px rgba(2, 8, 26, 0.6);
+}
+
+body.theme-dark .site-footer {
+    background: #080f1f;
+    color: rgba(230, 236, 255, 0.82);
+}
+
+body.theme-dark .footer-links h3 {
+    color: var(--text);
+}
+
+body.theme-dark .footer-bottom {
+    border-top-color: rgba(133, 150, 210, 0.25);
+}
+
 * {
     box-sizing: border-box;
 }
@@ -572,6 +632,57 @@ img {
 .btn.ghost:focus {
     background: rgba(58, 111, 247, 0.08);
     transform: translateY(-1px);
+}
+
+.dark-mode-toggle {
+    position: fixed;
+    left: 1.5rem;
+    bottom: 1.5rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.65rem 1.1rem;
+    border-radius: 999px;
+    background: var(--white);
+    color: var(--text);
+    border: 1px solid var(--border);
+    box-shadow: 0 16px 32px rgba(15, 31, 76, 0.25);
+    cursor: pointer;
+    z-index: 80;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, color 0.3s ease,
+        border-color 0.3s ease;
+}
+
+.dark-mode-toggle:hover,
+.dark-mode-toggle:focus {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 36px rgba(15, 31, 76, 0.3);
+}
+
+.dark-mode-toggle:focus {
+    outline: 3px solid rgba(58, 111, 247, 0.35);
+    outline-offset: 3px;
+}
+
+.dark-mode-toggle__icon {
+    font-size: 1.1rem;
+    line-height: 1;
+}
+
+.dark-mode-toggle__label {
+    font-weight: 600;
+}
+
+body.theme-dark .dark-mode-toggle {
+    border-color: rgba(133, 150, 210, 0.45);
+    box-shadow: 0 20px 38px rgba(3, 8, 24, 0.55);
+}
+
+@media (max-width: 640px) {
+    .dark-mode-toggle {
+        left: 1rem;
+        bottom: 1rem;
+    }
 }
 
 .scroll-to-top {

--- a/awards.html
+++ b/awards.html
@@ -472,5 +472,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/campus-life.html
+++ b/campus-life.html
@@ -464,5 +464,6 @@
             <p>© 2024 Seoul Cyber Campus. All rights reserved.</p>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/contact-directory.html
+++ b/contact-directory.html
@@ -471,5 +471,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/convergence.html
+++ b/convergence.html
@@ -458,5 +458,6 @@
             <p>© 2024 Seoul Cyber Campus. All rights reserved.</p>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/directions.html
+++ b/directions.html
@@ -463,5 +463,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/donations.html
+++ b/donations.html
@@ -456,5 +456,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/education-philosophy.html
+++ b/education-philosophy.html
@@ -457,5 +457,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/faculty-staff.html
+++ b/faculty-staff.html
@@ -462,5 +462,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/financial-reports.html
+++ b/financial-reports.html
@@ -483,5 +483,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/foundation.html
+++ b/foundation.html
@@ -466,5 +466,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/greeting.html
+++ b/greeting.html
@@ -457,5 +457,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/industry-collaboration.html
+++ b/industry-collaboration.html
@@ -466,5 +466,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/information-disclosure.html
+++ b/information-disclosure.html
@@ -464,5 +464,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/media-kit.html
+++ b/media-kit.html
@@ -465,5 +465,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/news.html
+++ b/news.html
@@ -475,5 +475,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/non-tenure-faculty.html
+++ b/non-tenure-faculty.html
@@ -462,5 +462,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/organization.html
+++ b/organization.html
@@ -466,5 +466,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/partnerships.html
+++ b/partnerships.html
@@ -465,5 +465,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/press.html
+++ b/press.html
@@ -460,5 +460,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/programs.html
+++ b/programs.html
@@ -548,5 +548,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/public-info.html
+++ b/public-info.html
@@ -464,5 +464,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/school-relations.html
+++ b/school-relations.html
@@ -465,5 +465,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/sdu-2025.html
+++ b/sdu-2025.html
@@ -457,5 +457,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/sdu-specialization.html
+++ b/sdu-specialization.html
@@ -457,5 +457,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/social-contribution.html
+++ b/social-contribution.html
@@ -466,5 +466,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/status.html
+++ b/status.html
@@ -465,5 +465,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/support.html
+++ b/support.html
@@ -517,5 +517,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/tutor-overview.html
+++ b/tutor-overview.html
@@ -462,5 +462,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/ui-guidelines.html
+++ b/ui-guidelines.html
@@ -461,5 +461,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/university-overview.html
+++ b/university-overview.html
@@ -471,5 +471,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/why-sdu.html
+++ b/why-sdu.html
@@ -456,5 +456,6 @@
             </div>
         </div>
     </footer>
+    <script src="assets/js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure the translation control is available on every page, including a Google Translate fallback when no inline English copy exists, and add a persistent dark mode toggle
- introduce dark theme variables and component styles so the new mode renders cleanly
- include the shared script bundle on each HTML page so the translation and theme controls load everywhere

## Testing
- Not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68de24bc908c8332a947633f9552a551