### PR TITLE
Add embedded YouTube showcase above homepage footer

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1206,6 +1206,43 @@ body.theme-dark .dark-mode-toggle {
     margin: 0.75rem auto 2rem;
 }
 
+.video-showcase {
+    padding: 4rem 0;
+    background: var(--white);
+}
+
+.video-showcase h2 {
+    text-align: center;
+    font-size: 2rem;
+    margin-bottom: 0.75rem;
+}
+
+.video-showcase .video-description {
+    text-align: center;
+    max-width: 38rem;
+    margin: 0 auto 2rem;
+    color: var(--muted);
+}
+
+.video-wrapper {
+    position: relative;
+    width: min(960px, 100%);
+    margin: 0 auto;
+    padding-bottom: 56.25%;
+    border-radius: 1rem;
+    overflow: hidden;
+    box-shadow: 0 20px 40px rgba(15, 31, 76, 0.15);
+    background: #000;
+}
+
+.video-wrapper iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
 .site-footer {
     background: #121a2f;
     color: rgba(255, 255, 255, 0.78);
@@ -1260,6 +1297,18 @@ body.theme-dark .dark-mode-toggle {
     .cta-group {
         width: 100%;
         justify-content: center;
+    }
+
+    .video-showcase {
+        padding: 3rem 0;
+    }
+
+    .video-showcase h2 {
+        font-size: 1.6rem;
+    }
+
+    .video-showcase .video-description {
+        margin-bottom: 1.5rem;
     }
 
     .footer-bottom {

--- a/index.html
+++ b/index.html
@@ -785,6 +785,22 @@
                 <a class="btn primary" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">지금 지원하기</a>
             </div>
         </section>
+
+        <section class="video-showcase" aria-label="서울 사이버 캠퍼스 홍보 영상">
+            <div class="container">
+                <h2>캠퍼스를 영상으로 만나보세요</h2>
+                <p class="video-description">서울 사이버 캠퍼스의 학습 환경과 프로그램을 한눈에 확인할 수 있는 공식 소개 영상입니다.</p>
+                <div class="video-wrapper">
+                    <iframe
+                        src="https://www.youtube.com/embed/2ggHiiRfnIE?si=ueRq8uqUdnZ-zMGL"
+                        title="서울 사이버 캠퍼스 소개 영상"
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                        allowfullscreen
+                        loading="lazy"
+                    ></iframe>
+                </div>
+            </div>
+        </section>
     </main>
 
     <footer class="site-footer">


### PR DESCRIPTION
## Summary
- embed the official YouTube video above the homepage footer so visitors can watch it in-place
- style the new video section and ensure it remains responsive on smaller screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfc4c92c548332a89367025aab2812