### PR TITLE
Update site branding to GTCC crest

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>대학소개 | 서울 사이버 캠퍼스</title>
+    <title>대학소개 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/academics.html
+++ b/academics.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>학사안내 | 서울 사이버 캠퍼스</title>
+    <title>학사안내 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/adjunct-faculty.html
+++ b/adjunct-faculty.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>시간강사 정보 | 서울 사이버 캠퍼스</title>
+    <title>시간강사 정보 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/admissions-bulletin.html
+++ b/admissions-bulletin.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>입시 자료 공고 | 서울 사이버 캠퍼스</title>
+    <title>입시 자료 공고 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/admissions.html
+++ b/admissions.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>입학안내 | 서울 사이버 캠퍼스</title>
+    <title>입학안내 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -119,10 +119,49 @@ img {
 }
 
 .logo {
-    font-weight: 700;
-    font-size: 1.5rem;
-    letter-spacing: 0.05em;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
     color: var(--primary);
+    font-weight: 700;
+    font-size: 1.35rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+.logo img {
+    height: 3.25rem;
+    width: auto;
+    display: block;
+}
+
+.logo__text {
+    white-space: nowrap;
+    letter-spacing: 0.35em;
+}
+
+@media (max-width: 900px) {
+    .logo img {
+        height: 2.75rem;
+    }
+}
+
+@media (max-width: 640px) {
+    .logo {
+        gap: 0.5rem;
+        font-size: 1.1rem;
+        letter-spacing: 0.2em;
+    }
+
+    .logo img {
+        height: 2.25rem;
+    }
+}
+
+@media (max-width: 520px) {
+    .logo__text {
+        display: none;
+    }
 }
 
 .main-nav ul {

--- a/assets/icons/gtcc-logo.svg
+++ b/assets/icons/gtcc-logo.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">General Trias College of Cavite Emblem</title>
+  <desc id="desc">Circular maroon crest with a golden shield and the motto Veritas Freedom for the General Trias College of Cavite.</desc>
+  <defs>
+    <linearGradient id="shieldGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffd152" />
+      <stop offset="55%" stop-color="#f28f1a" />
+      <stop offset="100%" stop-color="#cc3d11" />
+    </linearGradient>
+    <linearGradient id="bannerGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#821428" />
+      <stop offset="50%" stop-color="#a61d32" />
+      <stop offset="100%" stop-color="#821428" />
+    </linearGradient>
+    <radialGradient id="innerGlow" cx="50%" cy="45%" r="60%">
+      <stop offset="0%" stop-color="#fff5d6" stop-opacity="0.95" />
+      <stop offset="60%" stop-color="#ffd152" stop-opacity="0.25" />
+      <stop offset="100%" stop-color="transparent" />
+    </radialGradient>
+    <clipPath id="shieldClip">
+      <path d="M256 136c-72.1 0-116 18.6-116 18.6v92.7c0 69.1 45.8 109 116 140.7 70.2-31.7 116-71.6 116-140.7v-92.7S328.1 136 256 136z" />
+    </clipPath>
+    <path id="outerTextPath" d="M256 60a196 196 0 1 1 0 392 196 196 0 1 1 0-392z" />
+    <path id="innerTextPath" d="M256 452a196 196 0 1 1 0-392 196 196 0 1 1 0 392z" />
+  </defs>
+  <circle cx="256" cy="256" r="244" fill="#6f1023" />
+  <circle cx="256" cy="256" r="228" fill="#b32032" />
+  <circle cx="256" cy="256" r="205" fill="#ffffff" />
+  <circle cx="256" cy="256" r="182" fill="#6f1023" />
+  <g font-family="'Cinzel', 'Times New Roman', serif" font-weight="600">
+    <text fill="#ffffff" font-size="38" letter-spacing="6">
+      <textPath href="#outerTextPath" startOffset="5%">GENERAL TRIAS COLLEGE OF CAVITE</textPath>
+    </text>
+    <text fill="#ffffff" font-size="34" letter-spacing="18">
+      <textPath href="#innerTextPath" startOffset="64%">2006</textPath>
+    </text>
+  </g>
+  <g clip-path="url(#shieldClip)">
+    <path d="M256 136c-72.1 0-116 18.6-116 18.6v92.7c0 69.1 45.8 109 116 140.7 70.2-31.7 116-71.6 116-140.7v-92.7S328.1 136 256 136z" fill="url(#shieldGradient)" stroke="#6f1023" stroke-width="10" />
+    <rect x="172" y="210" width="36" height="92" fill="#8f151f" rx="6" />
+    <rect x="220" y="210" width="36" height="92" fill="#8f151f" rx="6" />
+    <rect x="268" y="210" width="36" height="92" fill="#8f151f" rx="6" />
+    <rect x="316" y="210" width="36" height="92" fill="#8f151f" rx="6" />
+    <path d="M160 198h200" stroke="#6f1023" stroke-width="12" stroke-linecap="round" />
+    <path d="M256 198v170" stroke="#421417" stroke-width="14" stroke-linecap="round" />
+    <path d="M320 198v120" stroke="#421417" stroke-width="14" stroke-linecap="round" />
+    <path d="M192 198v120" stroke="#421417" stroke-width="14" stroke-linecap="round" />
+    <g transform="translate(256 258)">
+      <circle r="28" fill="#fff4d2" stroke="#6f1023" stroke-width="10" />
+      <path d="M0-16v32" stroke="#6f1023" stroke-width="8" stroke-linecap="round" />
+      <path d="M-16 0h32" stroke="#6f1023" stroke-width="8" stroke-linecap="round" />
+    </g>
+    <circle cx="256" cy="250" r="160" fill="url(#innerGlow)" />
+  </g>
+  <path d="M140 332h232l-32 64H172z" fill="url(#bannerGradient)" stroke="#6f1023" stroke-width="8" />
+  <text x="256" y="380" font-family="'Cinzel', 'Times New Roman', serif" font-size="42" font-weight="600" fill="#f6d9b2" text-anchor="middle" letter-spacing="8">VERITAS · FREEDOM</text>
+  <g fill="#ffffff">
+    <circle cx="156" cy="432" r="12" />
+    <circle cx="196" cy="440" r="12" />
+    <circle cx="236" cy="444" r="12" />
+    <circle cx="276" cy="444" r="12" />
+    <circle cx="316" cy="440" r="12" />
+    <circle cx="356" cy="432" r="12" />
+  </g>
+</svg>

--- a/awards.html
+++ b/awards.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>대학 인증·수상 | 서울 사이버 캠퍼스</title>
+    <title>대학 인증·수상 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/campus-life.html
+++ b/campus-life.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>대학생활 | 서울 사이버 캠퍼스</title>
+    <title>대학생활 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/contact-directory.html
+++ b/contact-directory.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전화번호 안내 | 서울 사이버 캠퍼스</title>
+    <title>전화번호 안내 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/convergence.html
+++ b/convergence.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>교육융합특성화 과정 | 서울 사이버 캠퍼스</title>
+    <title>교육융합특성화 과정 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/directions.html
+++ b/directions.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>찾아오시는 길 | 서울 사이버 캠퍼스</title>
+    <title>찾아오시는 길 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/donations.html
+++ b/donations.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>기부금품 안내 | 서울 사이버 캠퍼스</title>
+    <title>기부금품 안내 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/education-philosophy.html
+++ b/education-philosophy.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>교육이념 | 서울 사이버 캠퍼스</title>
+    <title>교육이념 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/faculty-staff.html
+++ b/faculty-staff.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전임교직원 정보 | 서울 사이버 캠퍼스</title>
+    <title>전임교직원 정보 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/financial-reports.html
+++ b/financial-reports.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>예결산 공시 | 서울 사이버 캠퍼스</title>
+    <title>예결산 공시 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/foundation.html
+++ b/foundation.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>학교법인 소개 | 서울 사이버 캠퍼스</title>
+    <title>학교법인 소개 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/greeting.html
+++ b/greeting.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>총장 인사말 | 서울 사이버 캠퍼스</title>
+    <title>총장 인사말 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>서울 사이버 캠퍼스</title>
+    <title>GTCC</title>
     <link rel="icon" type="image/svg+xml" href="assets/icons/school-favicon.svg" />
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -13,7 +13,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/industry-collaboration.html
+++ b/industry-collaboration.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>산업협력 | 서울 사이버 캠퍼스</title>
+    <title>산업협력 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/information-disclosure.html
+++ b/information-disclosure.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>대학정보공시 | 서울 사이버 캠퍼스</title>
+    <title>대학정보공시 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/media-kit.html
+++ b/media-kit.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>광고자료실 | 서울 사이버 캠퍼스</title>
+    <title>광고자료실 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/news.html
+++ b/news.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>새소식 | 서울 사이버 캠퍼스</title>
+    <title>새소식 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/non-tenure-faculty.html
+++ b/non-tenure-faculty.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>비전임교원 현황 | 서울 사이버 캠퍼스</title>
+    <title>비전임교원 현황 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/organization.html
+++ b/organization.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>조직도 | 서울 사이버 캠퍼스</title>
+    <title>조직도 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/partnerships.html
+++ b/partnerships.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>제휴협력 | 서울 사이버 캠퍼스</title>
+    <title>제휴협력 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/press.html
+++ b/press.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>보도기사 | 서울 사이버 캠퍼스</title>
+    <title>보도기사 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/programs.html
+++ b/programs.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>전공안내 | 서울 사이버 캠퍼스</title>
+    <title>전공안내 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/public-info.html
+++ b/public-info.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>정보공개 | 서울 사이버 캠퍼스</title>
+    <title>정보공개 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/school-relations.html
+++ b/school-relations.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>학교관계 | 서울 사이버 캠퍼스</title>
+    <title>학교관계 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/sdu-2025.html
+++ b/sdu-2025.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SDU 2025 | 서울 사이버 캠퍼스</title>
+    <title>SDU 2025 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/sdu-specialization.html
+++ b/sdu-specialization.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SDU 대학특성화 | 서울 사이버 캠퍼스</title>
+    <title>SDU 대학특성화 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/social-contribution.html
+++ b/social-contribution.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SDU 사회공헌 | 서울 사이버 캠퍼스</title>
+    <title>SDU 사회공헌 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/status.html
+++ b/status.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>대학 현황 | 서울 사이버 캠퍼스</title>
+    <title>대학 현황 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/support.html
+++ b/support.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>학생지원 | 서울 사이버 캠퍼스</title>
+    <title>학생지원 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/tutor-overview.html
+++ b/tutor-overview.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>튜터 현황 | 서울 사이버 캠퍼스</title>
+    <title>튜터 현황 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/ui-guidelines.html
+++ b/ui-guidelines.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>UI 가이드라인 | 서울 사이버 캠퍼스</title>
+    <title>UI 가이드라인 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/university-overview.html
+++ b/university-overview.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>대학 소개 | 서울 사이버 캠퍼스</title>
+    <title>대학 소개 | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">

--- a/why-sdu.html
+++ b/why-sdu.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Why SDU | 서울 사이버 캠퍼스</title>
+    <title>Why SDU | GTCC</title>
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,7 +12,10 @@
 <body>
     <header class="site-header">
         <div class="container">
-            <a class="logo" href="index.html">Seoul Cyber</a>
+            <a class="logo" href="index.html">
+                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">GTCC</span>
+            </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>
                     <li class="has-mega">


### PR DESCRIPTION
## Summary
- replace the header wordmark with a GTCC emblem graphic across every page
- update document titles to use the GTCC name instead of the previous Seoul Cyber branding
- add responsive styling so the new crest scales cleanly on smaller breakpoints

## Testing
- Manual QA: Viewed index page in browser

------
https://chatgpt.com/codex/tasks/task_e_68dfcaeeddf88332844de5b9b103b0c0