### PR TITLE
Move campus video under online learning guide

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1206,7 +1206,22 @@ body.theme-dark .dark-mode-toggle {
     border-radius: 1.5rem;
     padding: 2.5rem;
     display: grid;
-    gap: 1rem;
+    gap: 1.5rem;
+}
+
+.campus-video {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.campus-video h4 {
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.campus-video__description {
+    color: var(--muted);
+    line-height: 1.6;
 }
 
 .stats {

--- a/index.html
+++ b/index.html
@@ -756,6 +756,19 @@
                     <h3>온라인 학습 가이드</h3>
                     <p>원격 수업 참여를 위한 기술 가이드와 학습 도구 활용법을 확인하세요.</p>
                     <a class="btn ghost" href="#guide">가이드 다운로드</a>
+                    <div class="campus-video">
+                        <h4>캠퍼스를 영상으로 만나보세요</h4>
+                        <p class="campus-video__description">서울 사이버 캠퍼스의 학습 환경과 프로그램을 한눈에 확인할 수 있는 공식 소개 영상입니다.</p>
+                        <div class="video-wrapper">
+                            <iframe
+                                src="https://www.youtube.com/embed/2ggHiiRfnIE?si=ueRq8uqUdnZ-zMGL"
+                                title="서울 사이버 캠퍼스 소개 영상"
+                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                                allowfullscreen
+                                loading="lazy"
+                            ></iframe>
+                        </div>
+                    </div>
                 </div>
             </div>
         </section>
@@ -789,21 +802,6 @@
             </div>
         </section>
 
-        <section class="video-showcase" aria-label="서울 사이버 캠퍼스 홍보 영상">
-            <div class="container">
-                <h2>캠퍼스를 영상으로 만나보세요</h2>
-                <p class="video-description">서울 사이버 캠퍼스의 학습 환경과 프로그램을 한눈에 확인할 수 있는 공식 소개 영상입니다.</p>
-                <div class="video-wrapper">
-                    <iframe
-                        src="https://www.youtube.com/embed/2ggHiiRfnIE?si=ueRq8uqUdnZ-zMGL"
-                        title="서울 사이버 캠퍼스 소개 영상"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                        allowfullscreen
-                        loading="lazy"
-                    ></iframe>
-                </div>
-            </div>
-        </section>
     </main>
 
     <footer class="site-footer">


### PR DESCRIPTION
## Summary
- embed the campus promotional video directly beneath the online learning guide call-to-action on the main page
- remove the redundant standalone video section and adjust styles for the new nested video block

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dfcdd9edf48332952d9a420283ce25