### PR TITLE
Remove GTCC label from header logo and use PNG asset

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/academics.html
+++ b/academics.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/adjunct-faculty.html
+++ b/adjunct-faculty.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/admissions-bulletin.html
+++ b/admissions-bulletin.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/admissions.html
+++ b/admissions.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/awards.html
+++ b/awards.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/campus-life.html
+++ b/campus-life.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/contact-directory.html
+++ b/contact-directory.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/convergence.html
+++ b/convergence.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/directions.html
+++ b/directions.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/donations.html
+++ b/donations.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/education-philosophy.html
+++ b/education-philosophy.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/faculty-staff.html
+++ b/faculty-staff.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/financial-reports.html
+++ b/financial-reports.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/foundation.html
+++ b/foundation.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/greeting.html
+++ b/greeting.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/index.html
+++ b/index.html
@@ -14,8 +14,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/industry-collaboration.html
+++ b/industry-collaboration.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/information-disclosure.html
+++ b/information-disclosure.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/media-kit.html
+++ b/media-kit.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/news.html
+++ b/news.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/non-tenure-faculty.html
+++ b/non-tenure-faculty.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/organization.html
+++ b/organization.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/partnerships.html
+++ b/partnerships.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/press.html
+++ b/press.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/programs.html
+++ b/programs.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/public-info.html
+++ b/public-info.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/school-relations.html
+++ b/school-relations.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/sdu-2025.html
+++ b/sdu-2025.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/sdu-specialization.html
+++ b/sdu-specialization.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/social-contribution.html
+++ b/social-contribution.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/status.html
+++ b/status.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/support.html
+++ b/support.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/tutor-overview.html
+++ b/tutor-overview.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/ui-guidelines.html
+++ b/ui-guidelines.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/university-overview.html
+++ b/university-overview.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/why-sdu.html
+++ b/why-sdu.html
@@ -13,8 +13,7 @@
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">
-                <img src="assets/icons/gtcc-logo.svg" alt="General Trias College of Cavite emblem" />
-                <span class="logo__text">GTCC</span>
+                <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>


### PR DESCRIPTION
## Summary
- remove the GTCC text label from the header logo across all site pages
- update the header logo image to use `assets/icons/gtcc.png` everywhere

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68dfcf453024833293d180ba84b32ce0