### PR TITLE
Add General Trias College of Cavite text to navigation logo

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/academics.html
+++ b/academics.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/adjunct-faculty.html
+++ b/adjunct-faculty.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/admissions-bulletin.html
+++ b/admissions-bulletin.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/admissions.html
+++ b/admissions.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -138,6 +138,7 @@ img {
 .logo__text {
     white-space: nowrap;
     letter-spacing: 0.35em;
+    color: #000000;
 }
 
 @media (max-width: 900px) {

--- a/awards.html
+++ b/awards.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/campus-life.html
+++ b/campus-life.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/contact-directory.html
+++ b/contact-directory.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/convergence.html
+++ b/convergence.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/directions.html
+++ b/directions.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/donations.html
+++ b/donations.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/education-philosophy.html
+++ b/education-philosophy.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/faculty-staff.html
+++ b/faculty-staff.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/financial-reports.html
+++ b/financial-reports.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/foundation.html
+++ b/foundation.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/greeting.html
+++ b/greeting.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/industry-collaboration.html
+++ b/industry-collaboration.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/information-disclosure.html
+++ b/information-disclosure.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/media-kit.html
+++ b/media-kit.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/news.html
+++ b/news.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/non-tenure-faculty.html
+++ b/non-tenure-faculty.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/organization.html
+++ b/organization.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/partnerships.html
+++ b/partnerships.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/press.html
+++ b/press.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/programs.html
+++ b/programs.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/public-info.html
+++ b/public-info.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/school-relations.html
+++ b/school-relations.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/sdu-2025.html
+++ b/sdu-2025.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/sdu-specialization.html
+++ b/sdu-specialization.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/social-contribution.html
+++ b/social-contribution.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/status.html
+++ b/status.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/support.html
+++ b/support.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/tutor-overview.html
+++ b/tutor-overview.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/ui-guidelines.html
+++ b/ui-guidelines.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/university-overview.html
+++ b/university-overview.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/why-sdu.html
+++ b/why-sdu.html
@@ -14,6 +14,7 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">General Trias College of Cavite</span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>


### PR DESCRIPTION
## Summary
- add "General Trias College of Cavite" text next to the navigation logo on every page
- style the new logo text in black to match the requested appearance

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68dfd087e440833292fe200e1d86f793