### PR TITLE
Add top contact bar with admissions info

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/academics.html
+++ b/academics.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/adjunct-faculty.html
+++ b/adjunct-faculty.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/admissions-bulletin.html
+++ b/admissions-bulletin.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/admissions.html
+++ b/admissions.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -82,6 +82,77 @@ body {
     line-height: 1.6;
 }
 
+.top-bar {
+    background: var(--primary);
+    color: var(--white);
+    font-size: 0.9rem;
+}
+
+.top-bar a {
+    color: inherit;
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.top-bar a:hover,
+.top-bar a:focus {
+    text-decoration: underline;
+}
+
+.top-bar__content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1.5rem;
+    padding: 0.55rem 0;
+    flex-wrap: wrap;
+}
+
+.top-bar__item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    white-space: nowrap;
+}
+
+.top-bar__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.top-bar__divider {
+    width: 1px;
+    height: 1.25rem;
+    background: rgba(255, 255, 255, 0.4);
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
+@media (max-width: 720px) {
+    .top-bar__content {
+        justify-content: flex-start;
+        gap: 0.75rem;
+    }
+
+    .top-bar__divider {
+        display: none;
+    }
+
+    .top-bar__item {
+        white-space: normal;
+    }
+}
+
 a {
     color: inherit;
     text-decoration: none;

--- a/awards.html
+++ b/awards.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/campus-life.html
+++ b/campus-life.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/contact-directory.html
+++ b/contact-directory.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/convergence.html
+++ b/convergence.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/directions.html
+++ b/directions.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/donations.html
+++ b/donations.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/education-philosophy.html
+++ b/education-philosophy.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/faculty-staff.html
+++ b/faculty-staff.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/financial-reports.html
+++ b/financial-reports.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/foundation.html
+++ b/foundation.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/greeting.html
+++ b/greeting.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/index.html
+++ b/index.html
@@ -11,6 +11,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/industry-collaboration.html
+++ b/industry-collaboration.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/information-disclosure.html
+++ b/information-disclosure.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/media-kit.html
+++ b/media-kit.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/news.html
+++ b/news.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/non-tenure-faculty.html
+++ b/non-tenure-faculty.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/organization.html
+++ b/organization.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/partnerships.html
+++ b/partnerships.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/press.html
+++ b/press.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/programs.html
+++ b/programs.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/public-info.html
+++ b/public-info.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/school-relations.html
+++ b/school-relations.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/sdu-2025.html
+++ b/sdu-2025.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/sdu-specialization.html
+++ b/sdu-specialization.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/social-contribution.html
+++ b/social-contribution.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/status.html
+++ b/status.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/support.html
+++ b/support.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/tutor-overview.html
+++ b/tutor-overview.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/ui-guidelines.html
+++ b/ui-guidelines.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/university-overview.html
+++ b/university-overview.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">

--- a/why-sdu.html
+++ b/why-sdu.html
@@ -10,6 +10,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <div class="top-bar" role="complementary">
+        <div class="container top-bar__content">
+            <span class="top-bar__item">입학상담 전화<span class="sr-only">번호</span>: <a href="tel:0200001050">02-0000-1050</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <span class="top-bar__item">대표 이메일: <a href="mailto:info@sdu.ac.kr">info@sdu.ac.kr</a></span>
+            <span class="top-bar__divider" aria-hidden="true"></span>
+            <a class="top-bar__item top-bar__link" href="https://open.kakao.com/o/sBdzLw6e" target="_blank" rel="noopener noreferrer">카카오톡 상담</a>
+        </div>
+    </div>
     <header class="site-header">
         <div class="container">
             <a class="logo" href="index.html">


### PR DESCRIPTION
## Summary
- add a global top bar to every page with admissions phone, representative email, and KakaoTalk link
- style the top bar for accessibility and responsive layouts, including a screen-reader-only helper class

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfd31276488332abb5341e3e060d6f