### PR TITLE
Add stacked branding text next to header logo

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/academics.html
+++ b/academics.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/adjunct-faculty.html
+++ b/adjunct-faculty.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/admissions-bulletin.html
+++ b/admissions-bulletin.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/admissions.html
+++ b/admissions.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -213,6 +213,7 @@ img {
     font-size: 1.35rem;
     letter-spacing: 0.1em;
     text-transform: uppercase;
+    flex-shrink: 0;
 }
 
 .logo img {
@@ -222,8 +223,24 @@ img {
 }
 
 .logo__text {
-    white-space: nowrap;
-    letter-spacing: 0.35em;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    line-height: 1.15;
+    color: var(--primary);
+    letter-spacing: normal;
+    text-transform: none;
+    text-align: left;
+}
+
+.logo__line {
+    display: block;
+}
+
+.logo__line--secondary {
+    font-weight: 700;
 }
 
 @media (max-width: 900px) {

--- a/awards.html
+++ b/awards.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/campus-life.html
+++ b/campus-life.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/contact-directory.html
+++ b/contact-directory.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/convergence.html
+++ b/convergence.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/directions.html
+++ b/directions.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/donations.html
+++ b/donations.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/education-philosophy.html
+++ b/education-philosophy.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/faculty-staff.html
+++ b/faculty-staff.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/financial-reports.html
+++ b/financial-reports.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/foundation.html
+++ b/foundation.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/greeting.html
+++ b/greeting.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/industry-collaboration.html
+++ b/industry-collaboration.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/information-disclosure.html
+++ b/information-disclosure.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/media-kit.html
+++ b/media-kit.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/news.html
+++ b/news.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/non-tenure-faculty.html
+++ b/non-tenure-faculty.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/organization.html
+++ b/organization.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/partnerships.html
+++ b/partnerships.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/press.html
+++ b/press.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/programs.html
+++ b/programs.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/public-info.html
+++ b/public-info.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/school-relations.html
+++ b/school-relations.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/sdu-2025.html
+++ b/sdu-2025.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/sdu-specialization.html
+++ b/sdu-specialization.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/social-contribution.html
+++ b/social-contribution.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/status.html
+++ b/status.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/support.html
+++ b/support.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/tutor-overview.html
+++ b/tutor-overview.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/ui-guidelines.html
+++ b/ui-guidelines.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/university-overview.html
+++ b/university-overview.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>

--- a/why-sdu.html
+++ b/why-sdu.html
@@ -27,6 +27,10 @@
         <div class="container">
             <a class="logo" href="index.html">
                 <img src="assets/icons/gtcc.png" alt="General Trias College of Cavite emblem" />
+                <span class="logo__text">
+                    <span class="logo__line">General Trias College of Cavite</span>
+                    <span class="logo__line logo__line--secondary">Cyber College</span>
+                </span>
             </a>
             <nav class="main-nav" aria-label="주요 메뉴">
                 <ul>


### PR DESCRIPTION
## Summary
- add stacked "General Trias College of Cavite / Cyber College" text next to the site logo across all pages
- refine header logo styling so the new brand lines display compactly without crowding the navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfd8fb7714833295ffbf9b74c480f2