### PR TITLE
Adjust logo text alignment and secondary line size

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -233,6 +233,7 @@ img {
     letter-spacing: normal;
     text-transform: none;
     text-align: left;
+    align-items: flex-start;
 }
 
 .logo__line {
@@ -241,6 +242,7 @@ img {
 
 .logo__line--secondary {
     font-weight: 700;
+    font-size: 0.65rem;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- align the stacked logo text flush-left to ensure consistent presentation beside the emblem
- reduce the "Cyber College" line size to better differentiate the secondary label

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68dfe071906883329b759be5e4a89f38