### PR TITLE
Align logo text to the right

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -232,7 +232,8 @@ img {
     color: var(--primary);
     letter-spacing: normal;
     text-transform: none;
-    text-align: left;
+    text-align: right;
+    align-items: flex-end;
     justify-content: flex-end;
 }
 


### PR DESCRIPTION
## Summary
- adjust the header logo text styles so the lines are right-aligned and visually grouped on the right side of the logo

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68dfe42d298083329a43e219b252551e