### PR TITLE
Fix mega menu clipping on small screens

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1583,3 +1583,38 @@ body.theme-dark .dark-mode-toggle {
         padding: 4rem 0 2.5rem;
     }
 }
+
+@media (max-width: 820px) {
+    .main-nav {
+        width: 100%;
+    }
+
+    .main-nav ul {
+        row-gap: 0.75rem;
+    }
+}
+
+@media (max-width: 768px) {
+    .main-nav {
+        position: relative;
+    }
+
+    .main-nav li {
+        position: static;
+    }
+
+    .mega-menu {
+        left: 50%;
+        width: min(640px, calc(100vw - 2.5rem));
+        transform: translate(-50%, 10px);
+    }
+}
+
+@media (max-width: 560px) {
+    .mega-menu {
+        width: calc(100vw - 2rem);
+        padding: 1.75rem 1.5rem;
+        max-height: calc(100vh - 6rem);
+        overflow-y: auto;
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the navigation bar spans the full width on narrow screens and provide row spacing for wrapped items
- reposition mega menus relative to the full navigation container so the panels stay centered and visible on small devices
- add tighter widths, padding adjustments, and scrolling for the mega menu at mobile breakpoints to prevent clipping

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68dff88913d48332914c156ef5386fd6