### PR TITLE
Prevent submenu titles from wrapping on small screens

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -393,6 +393,9 @@ img {
     color: var(--white);
     font-weight: 400;
     line-height: 1.4;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .mega-section ul a:hover,


### PR DESCRIPTION
## Summary
- keep mega menu submenu titles on a single line by preventing text wrapping
- add ellipsis overflow handling so long titles do not break the layout on narrow viewports

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e0019989a08332a4175d32168369c6