### PR TITLE
Restore Student Support and Campus News mega menus

### DIFF
--- a/admissions.html
+++ b/admissions.html
@@ -99,7 +99,7 @@
             </div>
         </section>
 
-        <section class="section">
+        <section id="scholarship" class="section">
             <div class="container split">
                 <div>
                     <h2>장학 및 재정 지원</h2>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -417,6 +417,24 @@ img {
     font-size: 0.8rem;
 }
 
+.mega-promo {
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.mega-promo strong {
+    font-size: 1.05rem;
+}
+
+.mega-promo p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.75);
+    line-height: 1.5;
+}
+
 .content-page {
     background: var(--white);
 }

--- a/assets/partials/header.html
+++ b/assets/partials/header.html
@@ -217,11 +217,87 @@
                         </div>
                     </div>
                 </li>
-                <li>
-                    <a href="support.html">학생지원</a>
+                <li class="has-mega">
+                    <a href="support.html" aria-haspopup="true">학생지원</a>
+                    <div class="mega-menu" role="menu">
+                        <div class="mega-columns">
+                            <div class="mega-column">
+                                <section class="mega-section">
+                                    <h3>학습 지원</h3>
+                                    <ul>
+                                        <li><a href="support.html#services">학생 지원 서비스</a></li>
+                                        <li><a href="support.html#coaching">1:1 학습 코칭</a></li>
+                                        <li><a href="support.html#guide">온라인 학습 가이드</a></li>
+                                    </ul>
+                                </section>
+                                <section class="mega-section">
+                                    <a class="mega-heading" href="support.html">지원 센터 바로가기</a>
+                                </section>
+                            </div>
+                            <div class="mega-column">
+                                <section class="mega-section">
+                                    <h3>커리어 & 상담</h3>
+                                    <ul>
+                                        <li><a href="support.html#career">커리어 개발 지원</a></li>
+                                        <li><a href="support.html#guide">장학 · 등록 안내</a></li>
+                                        <li><a href="contact-directory.html">담당자 연락처</a></li>
+                                    </ul>
+                                </section>
+                                <section class="mega-section">
+                                    <h3>자주 찾는 정보</h3>
+                                    <ul>
+                                        <li><a href="admissions.html#scholarship">장학 제도 살펴보기</a></li>
+                                        <li><a href="why-sdu.html">재학생 혜택</a></li>
+                                    </ul>
+                                </section>
+                            </div>
+                            <div class="mega-column">
+                                <section class="mega-section">
+                                    <div class="mega-promo">
+                                        <strong>상담이 필요하신가요?</strong>
+                                        <p>온라인 상담을 예약하고 전담 코치와 1:1로 이야기하세요.</p>
+                                        <a class="btn ghost" href="support.html#coaching">상담 신청</a>
+                                    </div>
+                                </section>
+                            </div>
+                        </div>
+                    </div>
                 </li>
-                <li>
-                    <a href="news.html">대학소식</a>
+                <li class="has-mega">
+                    <a href="news.html" aria-haspopup="true">대학소식</a>
+                    <div class="mega-menu" role="menu">
+                        <div class="mega-columns">
+                            <div class="mega-column">
+                                <section class="mega-section">
+                                    <h3>최신 소식</h3>
+                                    <ul>
+                                        <li><a href="news.html#latest-news">공지 & 학사 안내</a></li>
+                                        <li><a href="news.html#latest-news">행사 · 세미나</a></li>
+                                        <li><a href="news.html#newsletter">뉴스레터 구독</a></li>
+                                    </ul>
+                                </section>
+                            </div>
+                            <div class="mega-column">
+                                <section class="mega-section">
+                                    <h3>미디어</h3>
+                                    <ul>
+                                        <li><a href="press.html">보도자료</a></li>
+                                        <li><a href="awards.html">인증 · 수상</a></li>
+                                        <li><a href="media-kit.html">홍보 자료실</a></li>
+                                    </ul>
+                                </section>
+                            </div>
+                            <div class="mega-column">
+                                <section class="mega-section">
+                                    <div class="mega-promo">
+                                        <strong>뉴스레터 신청</strong>
+                                        <p>매월 발행되는 뉴스레터로 캠퍼스 소식을 받아보세요.</p>
+                                        <a class="btn ghost" href="news.html#newsletter">구독하기</a>
+                                    </div>
+                                </section>
+                            </div>
+                        </div>
+                    </div>
                 </li>
             </ul>
         </nav>

--- a/news.html
+++ b/news.html
@@ -33,7 +33,7 @@
             </div>
         </section>
 
-        <section class="section news">
+        <section id="latest-news" class="section news">
             <div class="container">
                 <div class="section-heading">
                     <h2>최신 뉴스</h2>

--- a/support.html
+++ b/support.html
@@ -33,7 +33,7 @@
             </div>
         </section>
 
-        <section class="section support">
+        <section id="services" class="section support">
             <div class="container split">
                 <div>
                     <h2>학생 지원 서비스</h2>
@@ -82,7 +82,7 @@
             </div>
         </section>
 
-        <section class="section">
+        <section id="career" class="section">
             <div class="container split">
                 <div>
                     <h2>커리어 개발 지원</h2>


### PR DESCRIPTION
## Summary
- restore dedicated mega menus for the 학생지원 and 대학소식 navigation items with curated quick links and CTAs
- add section anchors on 학생지원, 대학소식, and 입학안내 pages to support the restored submenu links
- style new mega menu promo blocks for consistent presentation

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e0a94cb8308332b1d69105dc772876