### PR TITLE
Update hero slider backgrounds with varied gradients

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
                     aria-roledescription="slide"
                     aria-label="1 / 5"
                     aria-hidden="false"
-                    style="--hero-background: linear-gradient(135deg, #0f1f4c 0%, #274bdb 55%, #6a8bff 100%); --badge-background: rgba(255, 255, 255, 0.22); --badge-color: #ffffff; --hero-text-color: #ffffff; --hero-body-color: rgba(255, 255, 255, 0.82); --hero-ghost-color: #ffffff; --hero-ghost-border: rgba(255, 255, 255, 0.65); --hero-ghost-hover: rgba(255, 255, 255, 0.18); --floating-card-bg: rgba(15, 31, 76, 0.78); --floating-card-color: #ffffff; --floating-card-link: #e5ecff;"
+                    style="--hero-background: linear-gradient(135deg, #0f172a 0%, #1d4ed8 55%, #6366f1 100%); --badge-background: rgba(255, 255, 255, 0.18); --badge-color: #e0e7ff; --hero-text-color: #ffffff; --hero-body-color: rgba(226, 232, 240, 0.86); --hero-ghost-color: #e0e7ff; --hero-ghost-border: rgba(226, 232, 240, 0.5); --hero-ghost-hover: rgba(226, 232, 240, 0.2); --floating-card-bg: rgba(15, 23, 42, 0.78); --floating-card-color: #f8fafc; --floating-card-link: #c7d2fe;"
                 >
                     <div class="container">
                         <div class="hero-text">
@@ -64,7 +64,7 @@
                     aria-roledescription="slide"
                     aria-label="2 / 5"
                     aria-hidden="true"
-                    style="--hero-background: linear-gradient(135deg, #0f1f4c 0%, #274bdb 55%, #6a8bff 100%); --badge-background: rgba(255, 255, 255, 0.22); --badge-color: #ffffff; --hero-text-color: #ffffff; --hero-body-color: rgba(255, 255, 255, 0.82); --hero-ghost-color: #ffffff; --hero-ghost-border: rgba(255, 255, 255, 0.65); --hero-ghost-hover: rgba(255, 255, 255, 0.18); --floating-card-bg: rgba(15, 31, 76, 0.78); --floating-card-color: #ffffff; --floating-card-link: #e5ecff;"
+                    style="--hero-background: linear-gradient(140deg, #0f766e 0%, #14b8a6 45%, #38bdf8 100%); --badge-background: rgba(255, 255, 255, 0.2); --badge-color: #ecfeff; --hero-text-color: #f0fdfa; --hero-body-color: rgba(240, 253, 250, 0.85); --hero-ghost-color: #ecfeff; --hero-ghost-border: rgba(240, 253, 250, 0.55); --hero-ghost-hover: rgba(236, 254, 255, 0.2); --floating-card-bg: rgba(15, 118, 110, 0.75); --floating-card-color: #faffff; --floating-card-link: #bbf7d0;"
                 >
                     <div class="container">
                         <div class="hero-text">
@@ -96,7 +96,7 @@
                     aria-roledescription="slide"
                     aria-label="3 / 5"
                     aria-hidden="true"
-                    style="--hero-background: linear-gradient(135deg, #0f1f4c 0%, #274bdb 55%, #6a8bff 100%); --badge-background: rgba(255, 255, 255, 0.22); --badge-color: #ffffff; --hero-text-color: #ffffff; --hero-body-color: rgba(255, 255, 255, 0.82); --hero-ghost-color: #ffffff; --hero-ghost-border: rgba(255, 255, 255, 0.65); --hero-ghost-hover: rgba(255, 255, 255, 0.18); --floating-card-bg: rgba(15, 31, 76, 0.78); --floating-card-color: #ffffff; --floating-card-link: #e5ecff;"
+                    style="--hero-background: linear-gradient(130deg, #8b5cf6 0%, #ec4899 55%, #fbbf24 100%); --badge-background: rgba(255, 255, 255, 0.18); --badge-color: #fdf2f8; --hero-text-color: #ffffff; --hero-body-color: rgba(255, 241, 242, 0.88); --hero-ghost-color: #fdf2f8; --hero-ghost-border: rgba(253, 242, 248, 0.55); --hero-ghost-hover: rgba(253, 242, 248, 0.22); --floating-card-bg: rgba(76, 29, 149, 0.72); --floating-card-color: #fdf4ff; --floating-card-link: #fce7f3;"
                 >
                     <div class="container">
                         <div class="hero-text">
@@ -128,7 +128,7 @@
                     aria-roledescription="slide"
                     aria-label="4 / 5"
                     aria-hidden="true"
-                    style="--hero-background: linear-gradient(135deg, #0f1f4c 0%, #274bdb 55%, #6a8bff 100%); --badge-background: rgba(255, 255, 255, 0.22); --badge-color: #ffffff; --hero-text-color: #ffffff; --hero-body-color: rgba(255, 255, 255, 0.82); --hero-ghost-color: #ffffff; --hero-ghost-border: rgba(255, 255, 255, 0.65); --hero-ghost-hover: rgba(255, 255, 255, 0.18); --floating-card-bg: rgba(15, 31, 76, 0.78); --floating-card-color: #ffffff; --floating-card-link: #e5ecff;"
+                    style="--hero-background: linear-gradient(140deg, #0f4c75 0%, #3282b8 50%, #bbe1fa 100%); --badge-background: rgba(255, 255, 255, 0.22); --badge-color: #e3f2fd; --hero-text-color: #f0f9ff; --hero-body-color: rgba(236, 248, 255, 0.85); --hero-ghost-color: #e3f2fd; --hero-ghost-border: rgba(227, 242, 253, 0.55); --hero-ghost-hover: rgba(227, 242, 253, 0.2); --floating-card-bg: rgba(15, 76, 117, 0.72); --floating-card-color: #f0f9ff; --floating-card-link: #cfe8ff;"
                 >
                     <div class="container">
                         <div class="hero-text">
@@ -159,7 +159,7 @@
                     aria-roledescription="slide"
                     aria-label="5 / 5"
                     aria-hidden="true"
-                    style="--hero-background: linear-gradient(135deg, #0f1f4c 0%, #274bdb 55%, #6a8bff 100%); --badge-background: rgba(255, 255, 255, 0.22); --badge-color: #ffffff; --hero-text-color: #ffffff; --hero-body-color: rgba(255, 255, 255, 0.82); --hero-ghost-color: #ffffff; --hero-ghost-border: rgba(255, 255, 255, 0.65); --hero-ghost-hover: rgba(255, 255, 255, 0.18); --floating-card-bg: rgba(15, 31, 76, 0.78); --floating-card-color: #ffffff; --floating-card-link: #e5ecff;"
+                    style="--hero-background: linear-gradient(135deg, #f97316 0%, #fb7185 50%, #c084fc 100%); --badge-background: rgba(255, 255, 255, 0.2); --badge-color: #fff7ed; --hero-text-color: #ffffff; --hero-body-color: rgba(255, 247, 237, 0.88); --hero-ghost-color: #fff7ed; --hero-ghost-border: rgba(255, 247, 237, 0.55); --hero-ghost-hover: rgba(255, 247, 237, 0.22); --floating-card-bg: rgba(124, 58, 237, 0.7); --floating-card-color: #fdf4ff; --floating-card-link: #fde68a;"
                 >
                     <div class="container">
                         <div class="hero-text">


### PR DESCRIPTION
## Summary
- apply unique gradient palettes to each hero slide for a trendier first impression
- tune associated badge and floating card color variables to maintain readability on every slide

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e0e2b299cc8332992b16d32009c320