### PR TITLE
Update site favicon to new GTCC icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GTCC</title>
-    <link rel="icon" type="image/svg+xml" href="assets/icons/school-favicon.svg" />
+    <link rel="icon" type="image/png" href="assets/icons/gtcc.png" />
     <link rel="stylesheet" href="assets/css/styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- update the favicon reference to use the PNG icon at assets/icons/gtcc.png

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2312e2a3c8332bf5d92112ccabd06