### PR TITLE
Add templates for academic program detail pages

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -959,6 +959,261 @@ body.theme-dark .dark-mode-toggle {
     color: var(--floating-card-link, var(--primary));
 }
 
+.department-hero {
+    background: linear-gradient(135deg, rgba(58, 111, 247, 0.16) 0%, rgba(23, 41, 92, 0.08) 60%, transparent 100%),
+        var(--white);
+    padding: 4rem 0 2.5rem;
+}
+
+.department-hero .container {
+    display: grid;
+    gap: 2rem;
+}
+
+.department-hero__label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(58, 111, 247, 0.12);
+    color: var(--primary-dark);
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.department-hero__label svg {
+    width: 1rem;
+    height: 1rem;
+    fill: currentColor;
+}
+
+.department-hero h1 {
+    margin: 1rem 0 0.75rem;
+    font-size: clamp(2.2rem, 4vw, 3rem);
+}
+
+.department-hero p {
+    color: var(--muted);
+    max-width: 48rem;
+    font-size: 1.05rem;
+}
+
+.department-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1.5rem;
+    margin-top: 1.5rem;
+}
+
+.department-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.55rem 1rem;
+    border-radius: 999px;
+    background: var(--bg);
+    color: var(--muted);
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.department-tabs {
+    border-top: 1px solid rgba(31, 42, 68, 0.08);
+    border-bottom: 1px solid rgba(31, 42, 68, 0.08);
+    background: var(--white);
+}
+
+.department-tabs .container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding: 0.75rem 0;
+}
+
+.department-tabs a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.55rem 1.2rem;
+    border-radius: 999px;
+    color: var(--muted);
+    font-weight: 600;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.department-tabs a:hover,
+.department-tabs a:focus {
+    background: rgba(58, 111, 247, 0.12);
+    color: var(--primary-dark);
+}
+
+.department-tabs a.is-active {
+    background: var(--primary);
+    color: var(--white);
+    box-shadow: 0 12px 24px rgba(58, 111, 247, 0.25);
+}
+
+.department-section {
+    padding: 3.5rem 0;
+}
+
+.department-section:nth-of-type(even) {
+    background: var(--bg);
+}
+
+.department-layout {
+    display: grid;
+    gap: 2.5rem;
+}
+
+.department-layout--split {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: start;
+    gap: 3rem;
+}
+
+.department-section h2 {
+    margin: 0 0 1.25rem;
+    font-size: clamp(1.75rem, 3vw, 2.3rem);
+}
+
+.department-section p {
+    color: var(--muted);
+    line-height: 1.8;
+    font-size: 1.02rem;
+}
+
+.department-list {
+    list-style: none;
+    margin: 2rem 0 0;
+    padding: 0;
+    display: grid;
+    gap: 1.5rem;
+}
+
+.department-list li {
+    background: var(--white);
+    border-radius: 1.25rem;
+    padding: 1.6rem 1.8rem;
+    box-shadow: 0 18px 40px rgba(17, 29, 63, 0.08);
+    position: relative;
+}
+
+.department-list li::before {
+    content: '';
+    position: absolute;
+    top: 1.8rem;
+    left: 1.4rem;
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 0.2rem;
+    background: var(--primary);
+    box-shadow: 0 0 0 6px rgba(58, 111, 247, 0.15);
+}
+
+.department-list__title {
+    margin: 0 0 0.4rem 1.6rem;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--text);
+}
+
+.department-list__subtitle {
+    margin: 0 0 0.75rem 1.6rem;
+    color: var(--primary-dark);
+    font-weight: 600;
+    font-size: 0.95rem;
+    letter-spacing: 0.01em;
+}
+
+.department-list__body {
+    margin: 0 0 0 1.6rem;
+    color: var(--muted);
+    line-height: 1.75;
+}
+
+.department-cards {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.department-card {
+    background: var(--white);
+    border-radius: 1.2rem;
+    padding: 1.8rem;
+    box-shadow: 0 18px 40px rgba(17, 29, 63, 0.08);
+}
+
+.department-card h3 {
+    margin: 0 0 0.75rem;
+    font-size: 1.2rem;
+}
+
+.department-card ul {
+    margin: 0;
+    padding-left: 1.1rem;
+    display: grid;
+    gap: 0.55rem;
+    color: var(--muted);
+    line-height: 1.7;
+}
+
+.career-grid {
+    display: grid;
+    gap: 1.4rem;
+}
+
+.career-card {
+    background: var(--white);
+    border-radius: 1.2rem;
+    padding: 1.6rem 1.8rem;
+    box-shadow: 0 16px 32px rgba(17, 29, 63, 0.08);
+}
+
+.career-card strong {
+    display: block;
+    margin-bottom: 0.65rem;
+    font-size: 1.15rem;
+}
+
+.department-cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-top: 2rem;
+}
+
+.department-cta .btn {
+    min-width: 180px;
+}
+
+@media (min-width: 768px) {
+    .department-cards {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .career-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 720px) {
+    .department-hero {
+        padding: 3.2rem 0 2rem;
+    }
+
+    .department-list li::before {
+        left: 1.1rem;
+    }
+
+    .department-list__title,
+    .department-list__subtitle,
+    .department-list__body {
+        margin-left: 1.35rem;
+    }
+}
+
 .hero-slider {
     position: relative;
     overflow: hidden;

--- a/assets/partials/header.html
+++ b/assets/partials/header.html
@@ -118,25 +118,25 @@
                                 <section class="mega-section">
                                     <h3>대학교</h3>
                                     <ul>
-                                        <li><a href="http://gtcc.edu.ph/academics/colleges/college-of-theology/">신학과</a></li>
-                                        <li><a href="http://gtcc.edu.ph/academics/colleges/college-of-theology/">기독교교육학과</a></li>
-                                        <li><a href="http://gtcc.edu.ph/academics/colleges/college-of-theology/">체육교육학과</a></li>
-                                        <li><a href="http://gtcc.edu.ph/academics/colleges/college-of-theology/">음악교육학과</a></li>
-                                        <li><a href="http://gtcc.edu.ph/academics/colleges/college-of-theology/">영어학과</a></li>
-                                        <li><a href="http://gtcc.edu.ph/academics/colleges/college-of-theology/">부동산학과</a></li>
-                                        <li><a href="http://gtcc.edu.ph/academics/colleges/college-of-theology/">행정학과</a></li>
-                                        <li><a href="http://gtcc.edu.ph/academics/colleges/college-of-theology/">상담학과</a></li>
-                                        <li><a href="http://gtcc.edu.ph/academics/colleges/college-of-theology/">복지학과</a></li>
-                                        <li><a href="http://gtcc.edu.ph/academics/colleges/college-of-theology/">경영학과</a></li>
-                                        <li><a href="http://gtcc.edu.ph/academics/colleges/college-of-theology/">관세학과</a></li>
+                                        <li><a href="college-theology.html">신학과</a></li>
+                                        <li><a href="college-christian-education.html">기독교교육학과</a></li>
+                                        <li><a href="college-physical-education.html">체육교육학과</a></li>
+                                        <li><a href="college-music-education.html">음악교육학과</a></li>
+                                        <li><a href="college-english.html">영어학과</a></li>
+                                        <li><a href="college-real-estate.html">부동산학과</a></li>
+                                        <li><a href="college-public-administration.html">행정학과</a></li>
+                                        <li><a href="college-counseling.html">상담학과</a></li>
+                                        <li><a href="college-social-welfare.html">복지학과</a></li>
+                                        <li><a href="college-business.html">경영학과</a></li>
+                                        <li><a href="college-customs.html">관세학과</a></li>
                                     </ul>
                                 </section>
                                 <section class="mega-section">
                                     <h3>대학원</h3>
                                     <ul>
-                                        <li><a href="http://gtcc.edu.ph/academics/colleges/college-of-theology/">신학대학원</a></li>
-                                        <li><a href="http://gtcc.edu.ph/academics/colleges/college-of-theology/">교육대학원</a></li>
-                                        <li><a href="http://gtcc.edu.ph/academics/colleges/college-of-theology/">경영대학원</a></li>
+                                        <li><a href="graduate-theology.html">신학대학원</a></li>
+                                        <li><a href="graduate-education.html">교육대학원</a></li>
+                                        <li><a href="graduate-business.html">경영대학원</a></li>
                                     </ul>
                                 </section>
                             </div>

--- a/college-business.html
+++ b/college-business.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>경영학과 | GTCC</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <span class="department-hero__label" aria-label="대학 과정">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                    Undergraduate Program
+                </span>
+                <h1>경영학과</h1>
+                <p>
+                    경영학과는 글로벌 비즈니스 환경에서 전략적으로 사고하고 실행할 수 있는 경영 리더를 양성합니다.
+                    데이터 기반 의사결정 능력과 스타트업/ESG 경영 역량을 함께 기릅니다.
+                </p>
+                <div class="department-meta">
+                    <span>학위과정: 학사(BBA)</span>
+                    <span>소속: 대학교</span>
+                    <span>표준수업연한: 4년</span>
+                </div>
+            </div>
+            <nav class="department-tabs" aria-label="경영학과 메뉴">
+                <div class="container">
+                    <a class="is-active" href="#overview">학과소개</a>
+                    <a href="#curriculum">교과과정</a>
+                    <a href="#career">진로 및 진출</a>
+                    <a href="#support">학생지원</a>
+                </div>
+            </nav>
+        </section>
+
+        <section id="overview" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학과소개</h2>
+                    <p>
+                        경영 전략, 마케팅, 재무, 인사, 데이터 분석 등 핵심 경영 영역을 실무 중심으로 학습합니다.
+                        글로벌 기업과 스타트업의 사례를 통해 혁신적 문제 해결 능력을 기릅니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">장학 · 등록 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">비즈니스 전략과 리더십</h3>
+                            <p class="department-list__subtitle">Business Strategy & Leadership</p>
+                            <p class="department-list__body">경영전략, 조직행동, 리더십 개발을 통해 글로벌 마켓을 이끄는 전략가로 성장합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">데이터 기반 경영</h3>
+                            <p class="department-list__subtitle">Data-driven Management</p>
+                            <p class="department-list__body">데이터 분석 도구와 BI 플랫폼을 활용해 시장 분석과 경영 의사결정을 지원합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">창업과 ESG 경영</h3>
+                            <p class="department-list__subtitle">Start-up & ESG Management</p>
+                            <p class="department-list__body">스타트업 프로젝트, ESG 경영 전략 수립을 통해 지속가능한 비즈니스 모델을 설계합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section">
+            <div class="container department-layout">
+                <div>
+                    <h2>교과과정 안내</h2>
+                    <p>
+                        경영 기초, 분석, 글로벌 전략, 창업/ESG 모듈로 구성되며 프로젝트 기반 학습을 강조합니다.
+                        기업 인턴십과 캡스톤 디자인을 통해 실전 능력을 강화합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>기초 영역</h3>
+                        <ul>
+                            <li>경영학원론</li>
+                            <li>회계원리</li>
+                            <li>경제학 기초</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>심화 영역</h3>
+                        <ul>
+                            <li>마케팅 전략</li>
+                            <li>재무관리 &amp; 투자</li>
+                            <li>인사·조직 혁신</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 연계</h3>
+                        <ul>
+                            <li>기업 인턴십 &amp; 현장실습</li>
+                            <li>경영 캡스톤 디자인</li>
+                            <li>스타트업/ESG 프로젝트</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section">
+            <div class="container department-layout">
+                <h2>진로 및 진출 분야</h2>
+                <p>
+                    마케팅/브랜드 매니저, 재무/회계 전문가, HR 매니저, 데이터 분석가, 스타트업 창업자 등으로 진출합니다.
+                    MBA, 경영학 대학원, 해외 비즈니스 스쿨 진학을 통한 경력 개발도 지원합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>기업 경영</strong>
+                        <p>국내외 기업 마케팅/재무/HR/전략 직무</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>데이터/컨설팅</strong>
+                        <p>경영 컨설턴트, 데이터 애널리스트, BI 스페셜리스트</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>창업/진학</strong>
+                        <p>MBA, 해외 경영대학원, 스타트업 창업 및 액셀러레이팅</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학생 지원 프로그램</h2>
+                    <p>
+                        취업 역량 강화 프로그램, 글로벌 교환, 창업 인큐베이터 등 실무 중심 지원을 제공합니다.
+                        기업 멘토링과 자격증 대비 특강으로 현장 경쟁력을 높입니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학사 지원</h3>
+                        <ul>
+                            <li>재무/회계 자격증 대비반</li>
+                            <li>데이터 분석 툴 워크숍</li>
+                            <li>취업 &amp; 창업 컨설팅</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>비즈니스 커뮤니티</h3>
+                        <ul>
+                            <li>기업 멘토 네트워킹</li>
+                            <li>스타트업 해커톤</li>
+                            <li>글로벌 비즈니스 포럼</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/college-christian-education.html
+++ b/college-christian-education.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>기독교교육학과 | GTCC</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <span class="department-hero__label" aria-label="대학 과정">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                    Undergraduate Program
+                </span>
+                <h1>기독교교육학과</h1>
+                <p>
+                    기독교교육학과는 신앙과 교육학을 융합하여 다음 세대와 지역사회에 영향력을 발휘할 교육 사역자를 양성합니다.
+                    교육공학 기반의 온라인 콘텐츠 설계 역량과 목회 현장의 실습 경험을 균형 있게 제공합니다.
+                </p>
+                <div class="department-meta">
+                    <span>학위과정: 학사(BA)</span>
+                    <span>소속: 대학교</span>
+                    <span>표준수업연한: 4년</span>
+                </div>
+            </div>
+            <nav class="department-tabs" aria-label="기독교교육학과 메뉴">
+                <div class="container">
+                    <a class="is-active" href="#overview">학과소개</a>
+                    <a href="#curriculum">교과과정</a>
+                    <a href="#career">진로 및 진출</a>
+                    <a href="#support">학생지원</a>
+                </div>
+            </nav>
+        </section>
+
+        <section id="overview" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학과소개</h2>
+                    <p>
+                        성경 세계관을 기반으로 한 교육 이론과 교수학습 전략을 학습하여 교회·학교·지역사회 교육 현장을 이끌 전문가를 양성합니다.
+                        교육 설계, 콘텐츠 제작, 학습자 상담 역량을 단계적으로 강화하여 실천적 교육 리더십을 기릅니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">장학 · 등록 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">신앙 기반 교육철학</h3>
+                            <p class="department-list__subtitle">Faith-based Educational Philosophy</p>
+                            <p class="department-list__body">성경적 세계관 위에서 교육철학과 교육심리학을 통합적으로 이해하고, 기독교 교육 목표를 설계합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">디지털 교수학습 설계</h3>
+                            <p class="department-list__subtitle">Digital Instructional Design</p>
+                            <p class="department-list__body">온라인과 하이브리드 수업을 위한 콘텐츠 제작, 학습자 분석, 교육공학 도구 활용 능력을 키웁니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">다음세대 교육 사역</h3>
+                            <p class="department-list__subtitle">Next Generation Ministry</p>
+                            <p class="department-list__body">유치·청소년·청년 사역 현장을 방문하여 교육 프로그램을 기획하고, 공동체 프로젝트를 수행합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section">
+            <div class="container department-layout">
+                <div>
+                    <h2>교과과정 안내</h2>
+                    <p>
+                        교육학 기초부터 커리큘럼 개발, 현장 실습까지 단계별 모듈로 구성되어 있습니다.
+                        프로젝트 기반 수업과 팀티칭을 통해 교육 콘텐츠 기획 및 실행 능력을 강화합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>기초 영역</h3>
+                        <ul>
+                            <li>기독교 교육철학</li>
+                            <li>교육심리와 상담</li>
+                            <li>성경적 리더십 기초</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>심화 영역</h3>
+                        <ul>
+                            <li>디지털 교수설계 워크숍</li>
+                            <li>세대별 교육 프로그램 개발</li>
+                            <li>교육 목회 행정</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 연계</h3>
+                        <ul>
+                            <li>교회/지역 교육 인턴십</li>
+                            <li>교육 콘텐츠 제작 프로젝트</li>
+                            <li>교육 사역 리트릿 및 컨퍼런스</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section">
+            <div class="container department-layout">
+                <h2>진로 및 진출 분야</h2>
+                <p>
+                    교회 교육 디렉터, 기독교 대안학교 교사, 온라인 교육 콘텐츠 기획자, 교육선교사 등 다양한 교육 사역으로 진출합니다.
+                    교육대학원 및 상담, 유아교육 등 관련 전공으로의 진학도 활발합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>교회 교육 사역</strong>
+                        <p>다음세대 교육 디렉터, 주일학교 커리큘럼 코디네이터, 교육선교사</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>교육 콘텐츠 분야</strong>
+                        <p>온라인 성경교육 콘텐츠 기획자, 교육 매체 개발자, 출판 편집</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>연구/진학</strong>
+                        <p>교육·상담 대학원, 기독교 교육 연구소, 교육 NGO</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학생 지원 프로그램</h2>
+                    <p>
+                        교육 콘텐츠 제작 실습실, 멘토 교사제, 교육 현장 탐방 등 현장 중심의 학습을 지원합니다.
+                        다양한 교육 봉사 동아리와 국제 교육 선교 연계를 통해 실무 경험을 확장합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학사 지원</h3>
+                        <ul>
+                            <li>교육 설계 멘토링 &amp; 튜터링</li>
+                            <li>다학제 융합 수업 설계 스터디</li>
+                            <li>교육 현장 실습 컨설팅</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>교육 커뮤니티</h3>
+                        <ul>
+                            <li>다음세대 교육 포럼</li>
+                            <li>교회/지역 연합 교육 프로젝트</li>
+                            <li>글로벌 교육 선교 교류</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/college-counseling.html
+++ b/college-counseling.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>상담학과 | GTCC</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <span class="department-hero__label" aria-label="대학 과정">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                    Undergraduate Program
+                </span>
+                <h1>상담학과</h1>
+                <p>
+                    상담학과는 심리학과 상담 이론을 바탕으로 개인과 공동체의 변화를 돕는 전문 상담가를 양성합니다.
+                    온라인 기반 사례관리와 대면 슈퍼비전을 병행하여 실무 역량을 강화합니다.
+                </p>
+                <div class="department-meta">
+                    <span>학위과정: 학사(BA)</span>
+                    <span>소속: 대학교</span>
+                    <span>표준수업연한: 4년</span>
+                </div>
+            </div>
+            <nav class="department-tabs" aria-label="상담학과 메뉴">
+                <div class="container">
+                    <a class="is-active" href="#overview">학과소개</a>
+                    <a href="#curriculum">교과과정</a>
+                    <a href="#career">진로 및 진출</a>
+                    <a href="#support">학생지원</a>
+                </div>
+            </nav>
+        </section>
+
+        <section id="overview" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학과소개</h2>
+                    <p>
+                        인간 발달과 심리 과정에 대한 깊은 이해를 바탕으로, 상담 이론과 실제를 통합한 실천형 커리큘럼을 제공합니다.
+                        학교, 청소년, 노인, 기업 등 다양한 현장에서 필요한 상담 역량을 키웁니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">장학 · 등록 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">심리 평가와 진단</h3>
+                            <p class="department-list__subtitle">Psychological Assessment & Diagnosis</p>
+                            <p class="department-list__body">심리검사 도구의 이해와 해석, 사례 개념화를 통해 정확한 상담 계획을 수립합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">상담 이론과 기법</h3>
+                            <p class="department-list__subtitle">Counseling Theories & Techniques</p>
+                            <p class="department-list__body">개인·집단·가족 상담 이론을 학습하고, 모의 상담과 슈퍼비전을 통해 실무 능력을 강화합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">통합적 사례관리</h3>
+                            <p class="department-list__subtitle">Integrated Case Management</p>
+                            <p class="department-list__body">다문화, 위기, 중독 등 다양한 클라이언트 상황을 다루며 윤리적 상담과 협업 체계를 확립합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section">
+            <div class="container department-layout">
+                <div>
+                    <h2>교과과정 안내</h2>
+                    <p>
+                        심리학 기초에서 상담 이론, 실습, 윤리까지 균형 있게 구성되어 있으며, 전문 자격 취득을 위한 실무 과목을 포함합니다.
+                        온라인 시뮬레이션과 오프라인 실습을 병행하여 현장 대응력을 높입니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>기초 영역</h3>
+                        <ul>
+                            <li>심리학개론</li>
+                            <li>발달심리</li>
+                            <li>상담윤리와 법</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>심화 영역</h3>
+                        <ul>
+                            <li>인지행동치료</li>
+                            <li>가족 및 부부상담</li>
+                            <li>위기개입과 트라우마 상담</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 연계</h3>
+                        <ul>
+                            <li>상담 실습 &amp; 슈퍼비전</li>
+                            <li>상담기관 인턴십</li>
+                            <li>심리검사 워크숍</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section">
+            <div class="container department-layout">
+                <h2>진로 및 진출 분야</h2>
+                <p>
+                    학교상담사, 청소년상담사, 정신건강상담사, 기업 EAP 컨설턴트, 복지기관 사례관리자 등으로 진출할 수 있습니다.
+                    상담심리 대학원, 사회복지 대학원 등 심화 진학도 지원합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>교육/청소년 분야</strong>
+                        <p>학교상담사, 청소년상담복지센터, Wee센터 상담전문가</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>정신건강 분야</strong>
+                        <p>정신건강상담센터, 병원 코디네이터, 중독재활 상담사</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>연구/진학</strong>
+                        <p>상담·임상심리 대학원, 사회복지/아동가족 전공, 상담 연구소</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학생 지원 프로그램</h2>
+                    <p>
+                        전문 상담사 자격증 대비반, 슈퍼비전 그룹, 심리검사 실습실을 운영하여 현장 적응력을 높입니다.
+                        온라인 상담센터와 연계한 실시간 상담 실습을 제공합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학사 지원</h3>
+                        <ul>
+                            <li>상담사 자격증 대비 세미나</li>
+                            <li>심리통계 &amp; 연구방법 워크숍</li>
+                            <li>사례개념화 클리닉</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>상담 커뮤니티</h3>
+                        <ul>
+                            <li>동료 상담 슈퍼비전 그룹</li>
+                            <li>마음건강 캠페인 봉사</li>
+                            <li>전문가 특강 &amp; 케이스 컨퍼런스</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/college-customs.html
+++ b/college-customs.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>관세학과 | GTCC</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <span class="department-hero__label" aria-label="대학 과정">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                    Undergraduate Program
+                </span>
+                <h1>관세학과</h1>
+                <p>
+                    관세학과는 글로벌 무역 현장에서 필요한 통관, 관세평가, 무역규범 전문 인력을 양성합니다.
+                    실무 중심 교육과 국제 교류를 통해 통상 전문가로 성장할 수 있습니다.
+                </p>
+                <div class="department-meta">
+                    <span>학위과정: 학사(BBA)</span>
+                    <span>소속: 대학교</span>
+                    <span>표준수업연한: 4년</span>
+                </div>
+            </div>
+            <nav class="department-tabs" aria-label="관세학과 메뉴">
+                <div class="container">
+                    <a class="is-active" href="#overview">학과소개</a>
+                    <a href="#curriculum">교과과정</a>
+                    <a href="#career">진로 및 진출</a>
+                    <a href="#support">학생지원</a>
+                </div>
+            </nav>
+        </section>
+
+        <section id="overview" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학과소개</h2>
+                    <p>
+                        관세 행정, 무역 실무, 국제 통상 협상 등을 체계적으로 학습하여 실무형 무역 전문가를 양성합니다.
+                        공인 관세사, 무역관리사 등 전문 자격 취득을 위한 맞춤형 교육을 제공합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">장학 · 등록 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">무역실무와 물류</h3>
+                            <p class="department-list__subtitle">Trade Practice & Logistics</p>
+                            <p class="department-list__body">무역계약, 결제, 국제물류 등 글로벌 비즈니스 프로세스를 실전 사례로 학습합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">관세법규와 평가</h3>
+                            <p class="department-list__subtitle">Customs Law & Valuation</p>
+                            <p class="department-list__body">관세법, 관세평가, 품목분류, 원산지 결정 기준을 사례 중심으로 학습합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">FTA &amp; 통상 전략</h3>
+                            <p class="department-list__subtitle">FTA & Trade Strategy</p>
+                            <p class="department-list__body">FTA 협정 활용, 통상 분쟁 대응, 글로벌 시장 분석을 통해 전략적 통상 역량을 강화합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section">
+            <div class="container department-layout">
+                <div>
+                    <h2>교과과정 안내</h2>
+                    <p>
+                        무역기초, 관세법규, 통관실무, FTA/통상 전략 영역으로 구성된 실무 중심 커리큘럼입니다.
+                        관세청, 물류기업과의 협력으로 현장 학습을 강화합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>기초 영역</h3>
+                        <ul>
+                            <li>무역학개론</li>
+                            <li>국제통상론</li>
+                            <li>무역영어</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>심화 영역</h3>
+                        <ul>
+                            <li>관세법규와 품목분류</li>
+                            <li>관세평가 및 과세가격</li>
+                            <li>통관실무 시뮬레이션</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 연계</h3>
+                        <ul>
+                            <li>세관 및 물류기업 인턴십</li>
+                            <li>FTA 컨설팅 프로젝트</li>
+                            <li>국제통상 경진대회</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section">
+            <div class="container department-layout">
+                <h2>진로 및 진출 분야</h2>
+                <p>
+                    관세사, 통관사, 무역관리사, 물류/포워딩 전문가, FTA 컨설턴트, 공공기관 통상 담당 등으로 진출합니다.
+                    관세사 시험 준비, 국제통상 대학원 등 진학을 위한 기초도 갖추게 됩니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>통관/관세 분야</strong>
+                        <p>관세법인, 관세사무소, 세관 통관 담당</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>무역/물류 분야</strong>
+                        <p>무역회사, 포워더, 글로벌 물류기업, 항만/항공 물류 담당</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>연구/진학</strong>
+                        <p>국제통상·관세 대학원, 정부 유관기관, 국제기구 통상 부서</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학생 지원 프로그램</h2>
+                    <p>
+                        관세사/무역자격 대비반, 관세청 멘토링, 해외 통상 기관 탐방 등 실무 중심 프로그램을 운영합니다.
+                        글로벌 교류 네트워크와 연계하여 현장 학습을 지원합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학사 지원</h3>
+                        <ul>
+                            <li>관세사 자격증 대비 스터디</li>
+                            <li>HS Code 실습 워크숍</li>
+                            <li>무역영어/LC 실무 클리닉</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>무역 커뮤니티</h3>
+                        <ul>
+                            <li>글로벌 통상 네트워킹</li>
+                            <li>무역실무 케이스 스터디</li>
+                            <li>국제박람회 봉사 및 탐방</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/college-english.html
+++ b/college-english.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>영어학과 | GTCC</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <span class="department-hero__label" aria-label="대학 과정">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                    Undergraduate Program
+                </span>
+                <h1>영어학과</h1>
+                <p>
+                    영어학과는 글로벌 커뮤니케이션 능력과 비즈니스 실무 역량을 갖춘 전문 인재를 양성합니다.
+                    언어학과 문학, 번역, 디지털 콘텐츠 제작 등 폭넓은 교육을 통해 국제 무대에서 활약할 수 있는 역량을 키웁니다.
+                </p>
+                <div class="department-meta">
+                    <span>학위과정: 학사(BA)</span>
+                    <span>소속: 대학교</span>
+                    <span>표준수업연한: 4년</span>
+                </div>
+            </div>
+            <nav class="department-tabs" aria-label="영어학과 메뉴">
+                <div class="container">
+                    <a class="is-active" href="#overview">학과소개</a>
+                    <a href="#curriculum">교과과정</a>
+                    <a href="#career">진로 및 진출</a>
+                    <a href="#support">학생지원</a>
+                </div>
+            </nav>
+        </section>
+
+        <section id="overview" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학과소개</h2>
+                    <p>
+                        학술 영어와 실용 영어를 균형 있게 학습하며, TESOL, 통번역, 국제 협력 분야에서 요구되는 의사소통 능력을 강화합니다.
+                        해외 대학과의 교류 및 인턴십을 통해 글로벌 현장 경험을 제공합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">장학 · 등록 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">학술 및 실용 영어</h3>
+                            <p class="department-list__subtitle">Academic & Practical English</p>
+                            <p class="department-list__body">학술적 글쓰기와 프레젠테이션, 비즈니스 커뮤니케이션을 통해 상황별 맞춤 언어 능력을 강화합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">글로벌 커뮤니케이션</h3>
+                            <p class="department-list__subtitle">Global Communication Practice</p>
+                            <p class="department-list__body">국제 회의 시뮬레이션, 교환학생 연계 프로젝트, 원어민 멘토링을 통해 실전형 소통 역량을 높입니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">콘텐츠 번역과 제작</h3>
+                            <p class="department-list__subtitle">Content Translation & Creation</p>
+                            <p class="department-list__body">문학 작품 번역, 글로벌 마케팅 콘텐츠 제작, 영어 교육 자료 개발을 통해 실무형 포트폴리오를 구축합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section">
+            <div class="container department-layout">
+                <div>
+                    <h2>교과과정 안내</h2>
+                    <p>
+                        언어학, 문학, 통번역, TESOL, 디지털 커뮤니케이션으로 구성된 모듈형 커리큘럼을 제공합니다.
+                        해외 인턴십과 글로벌 프로젝트를 통해 현장 경험을 쌓습니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>기초 영역</h3>
+                        <ul>
+                            <li>영어 문법 및 작문</li>
+                            <li>언어학 입문</li>
+                            <li>영미 문학 개론</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>심화 영역</h3>
+                        <ul>
+                            <li>번역·통역 실습</li>
+                            <li>TESOL 교수법</li>
+                            <li>글로벌 마케팅 커뮤니케이션</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 연계</h3>
+                        <ul>
+                            <li>해외 인턴십 &amp; 교환 프로그램</li>
+                            <li>국제회의 운영 프로젝트</li>
+                            <li>다국어 콘텐츠 제작 스튜디오</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section">
+            <div class="container department-layout">
+                <h2>진로 및 진출 분야</h2>
+                <p>
+                    통번역가, 영어 교사, 글로벌 마케터, 해외영업 전문가, 국제 NGO 코디네이터 등 다양한 분야로 진출합니다.
+                    통번역대학원, TESOL 대학원, 국제관계 전공 등으로의 진학도 활발합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>교육 분야</strong>
+                        <p>중등 영어교사, 영어 학습 콘텐츠 개발자, TESOL 전문 강사</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>비즈니스 분야</strong>
+                        <p>해외영업/무역 담당자, 글로벌 마케팅 콘텐츠 기획자, 스타트업 커뮤니케이터</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>연구/진학</strong>
+                        <p>통번역·TESOL 대학원, 국제관계/지역학 대학원, 외교/국제기구 준비</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학생 지원 프로그램</h2>
+                    <p>
+                        원어민 튜터링, 국제회의 참가 지원, 공인영어시험 대비 프로그램을 운영합니다.
+                        글로벌 교류 네트워크와 해외 인턴십을 통해 국제 현장 경험을 제공합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학사 지원</h3>
+                        <ul>
+                            <li>원어민 스피킹 클리닉</li>
+                            <li>공인영어시험 집중반</li>
+                            <li>영문 이력서/인터뷰 워크숍</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>글로벌 커뮤니티</h3>
+                        <ul>
+                            <li>국제 교류 동아리</li>
+                            <li>글로벌 이슈 토론회</li>
+                            <li>다국어 봉사 및 멘토링</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/college-music-education.html
+++ b/college-music-education.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>음악교육학과 | GTCC</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <span class="department-hero__label" aria-label="대학 과정">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                    Undergraduate Program
+                </span>
+                <h1>음악교육학과</h1>
+                <p>
+                    음악교육학과는 연주와 이론, 교육학을 통합하여 창의적이고 감성적인 음악 교육 전문가를 양성합니다.
+                    디지털 음향 기술과 문화예술교육 프로그램 설계 역량을 함께 갖춘 융합형 인재를 키웁니다.
+                </p>
+                <div class="department-meta">
+                    <span>학위과정: 학사(BMusEd)</span>
+                    <span>소속: 대학교</span>
+                    <span>표준수업연한: 4년</span>
+                </div>
+            </div>
+            <nav class="department-tabs" aria-label="음악교육학과 메뉴">
+                <div class="container">
+                    <a class="is-active" href="#overview">학과소개</a>
+                    <a href="#curriculum">교과과정</a>
+                    <a href="#career">진로 및 진출</a>
+                    <a href="#support">학생지원</a>
+                </div>
+            </nav>
+        </section>
+
+        <section id="overview" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학과소개</h2>
+                    <p>
+                        클래식과 실용음악, 음악교육 이론을 균형 있게 학습하여 학교와 지역사회, 문화예술 현장에서 활약할 음악교사를 양성합니다.
+                        온라인·오프라인 융합 수업을 통해 작곡, 편곡, 음향제작 능력도 함께 개발합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">장학 · 등록 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">음악 이론과 청음</h3>
+                            <p class="department-list__subtitle">Music Theory & Ear Training</p>
+                            <p class="department-list__body">화성학, 대위법, 시창청음 등 기초 이론을 탄탄히 다져 다양한 장르의 작품을 분석하고 지도할 수 있는 역량을 키웁니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">전공 실기 &amp; 앙상블</h3>
+                            <p class="department-list__subtitle">Applied Music & Ensemble</p>
+                            <p class="department-list__body">전공 악기/보컬 레슨과 앙상블 수업을 통해 무대 경험을 축적하고, 교육 현장에서 필요한 지휘와 반주 능력을 개발합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">문화예술 교육 기획</h3>
+                            <p class="department-list__subtitle">Arts & Culture Program Design</p>
+                            <p class="department-list__body">지역사회 음악회, 문화예술교육 프로그램을 직접 기획하고 운영하며 협업 능력과 프로젝트 관리 역량을 기릅니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section">
+            <div class="container department-layout">
+                <div>
+                    <h2>교과과정 안내</h2>
+                    <p>
+                        음악 기초 이론과 실기, 교육학, 문화예술경영 과목이 유기적으로 연결되어 있습니다.
+                        공연제작 프로젝트와 교육실습을 통해 실무 역량을 강화합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>기초 영역</h3>
+                        <ul>
+                            <li>화성학과 대위법</li>
+                            <li>시창·청음 트레이닝</li>
+                            <li>음악사 및 장르 연구</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>심화 영역</h3>
+                        <ul>
+                            <li>지휘법과 합창 지도</li>
+                            <li>음악교육 콘텐츠 개발</li>
+                            <li>디지털 음향 프로덕션</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 연계</h3>
+                        <ul>
+                            <li>학교 음악교육 실습</li>
+                            <li>앙상블/오케스트라 프로젝트</li>
+                            <li>문화예술교육 프로그램 운영</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section">
+            <div class="container department-layout">
+                <h2>진로 및 진출 분야</h2>
+                <p>
+                    음악교사, 문화예술교육사, 합창지휘자, 예술행정가, 음악 콘텐츠 제작자로 진출할 수 있습니다.
+                    교육대학원, 음악대학원, 문화예술경영 대학원 등으로의 진학도 활발합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>교육 분야</strong>
+                        <p>초·중등 음악교사, 예체능 방과후 지도사, 온라인 음악교육 전문가</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>공연/창작 분야</strong>
+                        <p>합창/밴드 지휘자, 작·편곡가, 세션 연주자, 음악 프로듀서</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>연구/진학</strong>
+                        <p>음악교육·음악치료 대학원, 문화예술경영 전공, 예술교육 연구소</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학생 지원 프로그램</h2>
+                    <p>
+                        1:1 전공실기 레슨, 마스터클래스, 녹음 스튜디오 실습 등 실연 역량을 강화하는 프로그램을 제공합니다.
+                        국제 음악 교육 워크숍과 지역문화 연계 프로젝트를 통해 현장 경험을 지원합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학사 지원</h3>
+                        <ul>
+                            <li>전공 실기 코칭 &amp; 반주 지원</li>
+                            <li>음악이론 집중 클리닉</li>
+                            <li>교원임용 대비 스터디</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>문화예술 커뮤니티</h3>
+                        <ul>
+                            <li>정기 연주회 및 버추얼 콘서트</li>
+                            <li>문화예술교육 봉사단</li>
+                            <li>글로벌 음악 워크숍 교류</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/college-physical-education.html
+++ b/college-physical-education.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>체육교육학과 | GTCC</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <span class="department-hero__label" aria-label="대학 과정">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                    Undergraduate Program
+                </span>
+                <h1>체육교육학과</h1>
+                <p>
+                    체육교육학과는 스포츠 과학과 교육학을 융합하여 건강한 공동체를 이끄는 체육 교사와 전문 코치를 양성합니다.
+                    최신 디지털 트레이닝 기법과 현장 실습을 통해 체육 지도 역량과 스포츠 콘텐츠 제작 능력을 기릅니다.
+                </p>
+                <div class="department-meta">
+                    <span>학위과정: 학사(BPE)</span>
+                    <span>소속: 대학교</span>
+                    <span>표준수업연한: 4년</span>
+                </div>
+            </div>
+            <nav class="department-tabs" aria-label="체육교육학과 메뉴">
+                <div class="container">
+                    <a class="is-active" href="#overview">학과소개</a>
+                    <a href="#curriculum">교과과정</a>
+                    <a href="#career">진로 및 진출</a>
+                    <a href="#support">학생지원</a>
+                </div>
+            </nav>
+        </section>
+
+        <section id="overview" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학과소개</h2>
+                    <p>
+                        스포츠 과학 지식과 교육 공학을 접목하여 학교·생활체육 현장에서 요구되는 전문 체육교육 인력을 양성합니다.
+                        다양한 종목 실기와 데이터 기반 트레이닝 분석 역량을 고르게 학습합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">장학 · 등록 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">스포츠 과학 기초</h3>
+                            <p class="department-list__subtitle">Sport Science Foundation</p>
+                            <p class="department-list__body">운동생리, 운동역학, 스포츠심리 등 과학적 이론을 체계적으로 학습하여 지도 역량의 기반을 다집니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">교육 및 코칭 설계</h3>
+                            <p class="department-list__subtitle">Pedagogy & Coaching Design</p>
+                            <p class="department-list__body">학습자 발달 단계에 맞는 수업 설계, 경기력 향상 프로그램 개발, 스마트 트레이닝 도구 활용법을 익힙니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">현장 실습과 경기 운영</h3>
+                            <p class="department-list__subtitle">Field Practice & Event Management</p>
+                            <p class="department-list__body">학교 체육수업 참관, 스포츠 축제 기획, 선수 트레이닝 캠프 운영 등 현장 경험을 폭넓게 제공합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section">
+            <div class="container department-layout">
+                <div>
+                    <h2>교과과정 안내</h2>
+                    <p>
+                        스포츠과학 이론과 실기, 교육학, 현장 실습이 단계적으로 배치되어 있습니다.
+                        실습 포트폴리오를 기반으로 교원 자격 취득과 생활체육 지도사 준비를 지원합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>기초 영역</h3>
+                        <ul>
+                            <li>운동생리학</li>
+                            <li>스포츠심리 및 발달</li>
+                            <li>체육측정평가</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>심화 영역</h3>
+                        <ul>
+                            <li>스포츠 교육과정 개발</li>
+                            <li>코칭 방법론과 전략</li>
+                            <li>스포츠미디어 콘텐츠 제작</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 연계</h3>
+                        <ul>
+                            <li>학교 체육수업 실습</li>
+                            <li>생활체육 지도 현장실습</li>
+                            <li>스포츠 이벤트 기획 프로젝트</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section">
+            <div class="container department-layout">
+                <h2>진로 및 진출 분야</h2>
+                <p>
+                    체육 교사, 생활체육 지도사, 스포츠 코치, 운동처방사, 스포츠 콘텐츠 기획자 등으로 진출할 수 있습니다.
+                    스포츠과학 대학원, 체육행정 전공 등 심화 진학도 지원합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>교육 현장</strong>
+                        <p>초·중등 체육교사, 방과후 스포츠 강사, 체육교과 컨설턴트</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>스포츠 산업</strong>
+                        <p>프로/아마추어 팀 코치, 스포츠 이벤트 매니저, 스포츠 미디어 기획</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>연구/진학</strong>
+                        <p>스포츠과학 대학원, 운동처방·재활 연구소, 체육행정 공공기관</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학생 지원 프로그램</h2>
+                    <p>
+                        스포츠 과학 연구실, 영상분석실, 현장 실습 연계 프로그램을 통해 실기와 연구 역량을 강화합니다.
+                        국제 스포츠 교류와 자격증 대비 특강을 운영하여 전문성을 높입니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학사 지원</h3>
+                        <ul>
+                            <li>스포츠과학 실험실 활용 세미나</li>
+                            <li>교원 자격 시험 대비 스터디</li>
+                            <li>생활체육 지도사 자격 준비반</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>스포츠 커뮤니티</h3>
+                        <ul>
+                            <li>종목별 선수 멘토링 네트워크</li>
+                            <li>스포츠 봉사 및 재능기부 프로그램</li>
+                            <li>국제 스포츠 교류 캠프</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/college-public-administration.html
+++ b/college-public-administration.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>행정학과 | GTCC</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <span class="department-hero__label" aria-label="대학 과정">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                    Undergraduate Program
+                </span>
+                <h1>행정학과</h1>
+                <p>
+                    행정학과는 공공정책 기획과 행정 운영 능력을 갖춘 공공 리더를 양성합니다.
+                    데이터 기반 행정과 디지털 거버넌스 역량을 강화하여 미래 지향적 행정 전문가를 배출합니다.
+                </p>
+                <div class="department-meta">
+                    <span>학위과정: 학사(BA)</span>
+                    <span>소속: 대학교</span>
+                    <span>표준수업연한: 4년</span>
+                </div>
+            </div>
+            <nav class="department-tabs" aria-label="행정학과 메뉴">
+                <div class="container">
+                    <a class="is-active" href="#overview">학과소개</a>
+                    <a href="#curriculum">교과과정</a>
+                    <a href="#career">진로 및 진출</a>
+                    <a href="#support">학생지원</a>
+                </div>
+            </nav>
+        </section>
+
+        <section id="overview" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학과소개</h2>
+                    <p>
+                        공공부문과 민간부문을 연결하는 정책 설계 능력과 조직 관리 역량을 갖춘 행정 전문가를 양성합니다.
+                        실사례 중심의 문제 해결 프로젝트를 통해 현장 경험을 쌓습니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">장학 · 등록 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">행정학 핵심 이론</h3>
+                            <p class="department-list__subtitle">Core Theories in Public Administration</p>
+                            <p class="department-list__body">행정학, 정치학, 경제학 등 기초 학문을 토대로 정책과 행정의 원리를 이해합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">데이터 기반 정책 분석</h3>
+                            <p class="department-list__subtitle">Data-driven Policy Analysis</p>
+                            <p class="department-list__body">통계와 빅데이터 도구를 활용하여 사회 문제를 진단하고 evidence-based 정책 대안을 도출합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">공공서비스 혁신</h3>
+                            <p class="department-list__subtitle">Public Service Innovation</p>
+                            <p class="department-list__body">스마트 행정, 거버넌스 협력, 사회적 가치 창출 프로젝트를 통해 시민 중심 행정을 실천합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section">
+            <div class="container department-layout">
+                <div>
+                    <h2>교과과정 안내</h2>
+                    <p>
+                        행정학 기초, 정책 분석, 조직관리, 공공재정, 전자정부 등으로 구성된 실무형 커리큘럼입니다.
+                        공공기관 사례 연구와 현장 실습을 통해 실전 능력을 키웁니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>기초 영역</h3>
+                        <ul>
+                            <li>행정학개론</li>
+                            <li>정치학개론</li>
+                            <li>미시/거시경제</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>심화 영역</h3>
+                        <ul>
+                            <li>공공재정 및 예산</li>
+                            <li>인사·조직 관리</li>
+                            <li>행정법과 규제정책</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 연계</h3>
+                        <ul>
+                            <li>공공기관/지자체 인턴십</li>
+                            <li>정책제안 해커톤</li>
+                            <li>시민참여 거버넌스 프로젝트</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section">
+            <div class="container department-layout">
+                <h2>진로 및 진출 분야</h2>
+                <p>
+                    5·7급 공무원, 공공기관 행정직, 정책연구원, 국제기구, 비영리단체 등 다양한 분야로 진출합니다.
+                    행정학·정책학 대학원, 로스쿨 등 심화 진학을 위한 기반도 제공합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>공공부문</strong>
+                        <p>국가·지방 공무원, 공기업 행정직, 공공서비스 기획자</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>정책/연구 분야</strong>
+                        <p>정책분석가, 연구기관 연구원, 국회 보좌진</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>국제/비영리 분야</strong>
+                        <p>국제기구 행정, NGO 프로젝트 매니저, 공공외교 전문가</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학생 지원 프로그램</h2>
+                    <p>
+                        공직시험 대비반, 정책 공모전 코칭, 행정 현장 견학 등 실무 역량 향상 프로그램을 제공합니다.
+                        국내외 공공기관과의 협력으로 인턴십과 멘토링을 운영합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학사 지원</h3>
+                        <ul>
+                            <li>공무원 시험 대비 스터디</li>
+                            <li>정책분석 통계워크숍</li>
+                            <li>행정법/헌법 모의고사</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>행정 커뮤니티</h3>
+                        <ul>
+                            <li>공공리더십 멘토링</li>
+                            <li>캠퍼스 정책 포럼</li>
+                            <li>지역사회 행정봉사 프로젝트</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/college-real-estate.html
+++ b/college-real-estate.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>부동산학과 | GTCC</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <span class="department-hero__label" aria-label="대학 과정">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                    Undergraduate Program
+                </span>
+                <h1>부동산학과</h1>
+                <p>
+                    부동산학과는 부동산 개발, 금융, 자산관리를 통합적으로 학습하여 부동산 전문 경영인을 양성합니다.
+                    데이터 분석과 법제 이해를 바탕으로 지속가능한 도시와 주거환경을 설계할 수 있는 능력을 키웁니다.
+                </p>
+                <div class="department-meta">
+                    <span>학위과정: 학사(BBA)</span>
+                    <span>소속: 대학교</span>
+                    <span>표준수업연한: 4년</span>
+                </div>
+            </div>
+            <nav class="department-tabs" aria-label="부동산학과 메뉴">
+                <div class="container">
+                    <a class="is-active" href="#overview">학과소개</a>
+                    <a href="#curriculum">교과과정</a>
+                    <a href="#career">진로 및 진출</a>
+                    <a href="#support">학생지원</a>
+                </div>
+            </nav>
+        </section>
+
+        <section id="overview" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학과소개</h2>
+                    <p>
+                        부동산 시장의 이해부터 개발 사업, 자산관리, 정책 분석까지 전 과정을 실무 중심으로 학습합니다.
+                        공인중개사, 감정평가사 등 전문 자격증 취득을 위한 체계적인 교육을 제공합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">장학 · 등록 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">부동산 시장 분석</h3>
+                            <p class="department-list__subtitle">Real Estate Market Analysis</p>
+                            <p class="department-list__body">부동산학 개론, 도시경제, 시장조사 방법을 통해 시장 동향을 정확히 파악하는 능력을 기릅니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">도시개발 전략</h3>
+                            <p class="department-list__subtitle">Urban Development Strategy</p>
+                            <p class="department-list__body">도시계획, 주택정책, 스마트시티 등 최신 이슈를 분석하고 개발 사업 기획 능력을 강화합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">부동산 데이터 &amp; 법제</h3>
+                            <p class="department-list__subtitle">Property Data & Legal Compliance</p>
+                            <p class="department-list__body">GIS와 빅데이터 분석, 부동산 관련 법규와 세제 이해를 통해 의사결정 역량을 높입니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section">
+            <div class="container department-layout">
+                <div>
+                    <h2>교과과정 안내</h2>
+                    <p>
+                        기초 부동산 이론, 개발 및 금융, 자산관리, 정책·법규 영역으로 구성된 실무 중심 커리큘럼입니다.
+                        프로젝트 기반 수업과 현장 견학을 통해 실전 감각을 기릅니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>기초 영역</h3>
+                        <ul>
+                            <li>부동산학개론</li>
+                            <li>도시경제학</li>
+                            <li>부동산법규 기초</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>심화 영역</h3>
+                        <ul>
+                            <li>부동산 투자 분석</li>
+                            <li>상업용 부동산 자산관리</li>
+                            <li>도시재생 프로젝트 실무</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 연계</h3>
+                        <ul>
+                            <li>부동산 개발 사례 분석 프로젝트</li>
+                            <li>공인중개 실무 인턴십</li>
+                            <li>도시재생 현장 견학</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section">
+            <div class="container department-layout">
+                <h2>진로 및 진출 분야</h2>
+                <p>
+                    공인중개사, 감정평가사, 부동산 자산관리사, 도시개발 컨설턴트, 공공기관 주택정책 담당 등 다양한 분야로 진출합니다.
+                    부동산·도시계획 대학원, MBA 등 심화 진학도 가능합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>부동산 중개·자산관리</strong>
+                        <p>공인중개사, 자산관리 매니저, 프롭테크 컨설턴트</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>개발·금융 분야</strong>
+                        <p>부동산 개발 기획자, 투자분석가, 금융기관 부동산 PF 담당</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>연구/진학</strong>
+                        <p>도시계획·부동산 대학원, 국토연구기관, 공기업 주택정책 부서</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학생 지원 프로그램</h2>
+                    <p>
+                        자격증 대비반, 산업체 멘토링, 실무 프로젝트 매칭 등 취업과 창업을 돕는 다양한 프로그램을 제공합니다.
+                        공공기관 및 민간기업과의 협약을 통해 현장 실습 기회를 확대합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학사 지원</h3>
+                        <ul>
+                            <li>공인중개사/감정평가사 대비반</li>
+                            <li>부동산 데이터 분석 워크숍</li>
+                            <li>부동산 법규 모의시험</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>산업 네트워크</h3>
+                        <ul>
+                            <li>부동산 전문가 특강 시리즈</li>
+                            <li>산학협력 프로젝트 팀빌딩</li>
+                            <li>도시재생 봉사 및 공공서비스</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/college-social-welfare.html
+++ b/college-social-welfare.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>복지학과 | GTCC</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <span class="department-hero__label" aria-label="대학 과정">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                    Undergraduate Program
+                </span>
+                <h1>복지학과</h1>
+                <p>
+                    복지학과는 사회적 약자를 지원하고 지역사회 복지를 증진할 전문 사회복지사를 양성합니다.
+                    정책 이해와 사례관리, 지역사회 개발을 통합적으로 학습합니다.
+                </p>
+                <div class="department-meta">
+                    <span>학위과정: 학사(BA)</span>
+                    <span>소속: 대학교</span>
+                    <span>표준수업연한: 4년</span>
+                </div>
+            </div>
+            <nav class="department-tabs" aria-label="복지학과 메뉴">
+                <div class="container">
+                    <a class="is-active" href="#overview">학과소개</a>
+                    <a href="#curriculum">교과과정</a>
+                    <a href="#career">진로 및 진출</a>
+                    <a href="#support">학생지원</a>
+                </div>
+            </nav>
+        </section>
+
+        <section id="overview" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학과소개</h2>
+                    <p>
+                        인간 존엄성과 사회 정의 실현을 위해 복지 이론과 실천을 아우르는 교육을 제공합니다.
+                        공공 및 민간 복지 영역에서 필요한 사례관리, 프로그램 기획 역량을 기릅니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">장학 · 등록 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">사회복지 이론</h3>
+                            <p class="department-list__subtitle">Social Welfare Theory</p>
+                            <p class="department-list__body">사회복지의 역사와 철학, 인간행동과 사회환경을 이해하고 실천의 기초를 다집니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">사례관리와 정책</h3>
+                            <p class="department-list__subtitle">Case Management & Policy</p>
+                            <p class="department-list__body">클라이언트 요구 평가, 개입 계획 수립, 복지 정책 분석을 통해 전문적 사례관리 능력을 강화합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">지역사회 개발</h3>
+                            <p class="department-list__subtitle">Community Development</p>
+                            <p class="department-list__body">지역 주민 참여 프로그램, 사회적 경제, 네트워킹을 통해 지속가능한 지역 복지 모델을 구축합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section">
+            <div class="container department-layout">
+                <div>
+                    <h2>교과과정 안내</h2>
+                    <p>
+                        사회복지 기초, 정책·행정, 대상자별 실천, 현장실습으로 구성된 커리큘럼입니다.
+                        현장 기관과 연계한 프로젝트를 통해 실무 역량을 높입니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>기초 영역</h3>
+                        <ul>
+                            <li>사회복지개론</li>
+                            <li>인간행동과 사회환경</li>
+                            <li>사회복지법제론</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>심화 영역</h3>
+                        <ul>
+                            <li>가족·아동·노인복지론</li>
+                            <li>사회복지조사와 평가</li>
+                            <li>복지행정 및 재정</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 연계</h3>
+                        <ul>
+                            <li>사회복지현장실습</li>
+                            <li>지역사회 복지 프로젝트</li>
+                            <li>사회적 기업 연계 프로그램</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section">
+            <div class="container department-layout">
+                <h2>진로 및 진출 분야</h2>
+                <p>
+                    사회복지사, 지역사회복지사, 복지관 프로그램 코디네이터, 공공기관 복지 담당, NGO 활동가 등으로 진출합니다.
+                    사회복지대학원, 보건복지정책 대학원 등 진학을 통해 전문성을 심화할 수 있습니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>사회복지 현장</strong>
+                        <p>사회복지관, 지역자활센터, 노인·장애인 복지시설</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>공공/정책 분야</strong>
+                        <p>지자체 복지 공무원, 공공기관 복지정책 담당자, 사회보장 행정</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>연구/진학</strong>
+                        <p>사회복지대학원, 보건복지정책 연구소, 국제개발 협력</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학생 지원 프로그램</h2>
+                    <p>
+                        사회복지사 자격증 대비반, 지역사회 봉사 네트워크, 사례관리 워크숍 등을 운영합니다.
+                        복지기관과 연계한 멘토링과 현장 실습 매칭을 제공합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학사 지원</h3>
+                        <ul>
+                            <li>사회복지사 1급 대비 스터디</li>
+                            <li>복지정책 세미나 &amp; 토론</li>
+                            <li>사례관리 보고서 코칭</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>복지 커뮤니티</h3>
+                        <ul>
+                            <li>지역사회 봉사 동아리</li>
+                            <li>사회적 경제 프로젝트</li>
+                            <li>국제 복지 교류 프로그램</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/college-theology.html
+++ b/college-theology.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>신학과 | GTCC</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <span class="department-hero__label" aria-label="대학 과정">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                    Undergraduate Program
+                </span>
+                <h1>신학과</h1>
+                <p>
+                    신학과는 성서와 교리를 체계적으로 탐구하며 시대적 요청에 응답할 수 있는 신앙 리더를 양성합니다.
+                    영성과 학문성을 겸비한 목회자와 신학자를 목표로 성서 해석, 역사·조직신학, 실천신학을 균형 있게 다룹니다.
+                </p>
+                <div class="department-meta">
+                    <span>학위과정: 학사(BA)</span>
+                    <span>소속: 대학교</span>
+                    <span>표준수업연한: 4년</span>
+                </div>
+            </div>
+            <nav class="department-tabs" aria-label="신학과 메뉴">
+                <div class="container">
+                    <a class="is-active" href="#overview">학과소개</a>
+                    <a href="#curriculum">교과과정</a>
+                    <a href="#career">진로 및 진출</a>
+                    <a href="#support">학생지원</a>
+                </div>
+            </nav>
+        </section>
+
+        <section id="overview" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학과소개</h2>
+                    <p>
+                        신학과는 성경 원어 연구와 기독교 전통 이해를 토대로 균형 잡힌 목회 사역 능력을 기르는 것을 목표로 합니다.
+                        복음의 본질을 탐구하면서도 현대 사회의 다양한 문제를 복음적으로 해석하고 소통할 수 있는 실천 신학적 감수성을 키웁니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">장학 · 등록 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">성서 해석과 교리 연구</h3>
+                            <p class="department-list__subtitle">Biblical Interpretation & Doctrine</p>
+                            <p class="department-list__body">히브리어와 헬라어 기초를 바탕으로 성서 본문을 분석하고, 조직신학 전 영역을 통합적으로 학습합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">목회 리더십 개발</h3>
+                            <p class="department-list__subtitle">Pastoral Leadership Practicum</p>
+                            <p class="department-list__body">예배와 설교, 기독교 교육, 상담 등 현장 목회를 위한 핵심 역량을 실제 사역 프로젝트와 연계하여 훈련합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">선교와 지역사회 봉사</h3>
+                            <p class="department-list__subtitle">Mission & Community Engagement</p>
+                            <p class="department-list__body">국내외 선교 현장을 탐방하고 지역사회 봉사 프로그램에 참여하여 신학적 실천력을 확장합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section">
+            <div class="container department-layout">
+                <div>
+                    <h2>교과과정 안내</h2>
+                    <p>
+                        기초 신학 이수 후 조직·역사·실천 영역으로 심화되는 모듈형 교과과정으로 편성되었습니다.
+                        온라인 강의와 집중 세미나, 목회 실습을 연계하여 학문과 실제를 통합적으로 경험할 수 있습니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>기초 영역</h3>
+                        <ul>
+                            <li>성경 히브리어/헬라어</li>
+                            <li>구약/신약 개론</li>
+                            <li>초대교회사</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>심화 영역</h3>
+                        <ul>
+                            <li>조직신학 특강</li>
+                            <li>설교 커뮤니케이션</li>
+                            <li>목회상담 세미나</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 연계</h3>
+                        <ul>
+                            <li>목회 실습(인턴십)</li>
+                            <li>국내외 단기 선교</li>
+                            <li>지역사회 봉사 프로젝트</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section">
+            <div class="container department-layout">
+                <h2>진로 및 진출 분야</h2>
+                <p>
+                    졸업 후 교단 목회자, 선교사, 군·병원·교정 사역자, 기독교 상담가, NGO 사역가 등 다양한 분야로 진출할 수 있습니다.
+                    국내외 신학대학원 진학을 위한 학문적 기반도 탄탄하게 다집니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>목회/선교 분야</strong>
+                        <p>교회 담임 및 부목사, 선교단체 간사, 지역사회 선교센터 리더</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>교육/상담 분야</strong>
+                        <p>기독교 교육 디렉터, 청소년 사역자, 기독교 상담 전문가</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>연구/진학</strong>
+                        <p>신학대학원 석·박사 과정, 기독교 연구소, 출판 및 미디어 사역</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학생 지원 프로그램</h2>
+                    <p>
+                        온라인 튜터링, 교수 멘토링, 영성 수련회 등 학문과 영성을 균형 있게 성장시키는 다양한 비교과 프로그램을 운영합니다.
+                        해외 신학대학과의 교류를 통해 글로벌 학습 기회를 제공합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학사 지원</h3>
+                        <ul>
+                            <li>전담 튜터 1:1 학습 코칭</li>
+                            <li>성서 원어 스터디 그룹 운영</li>
+                            <li>국내외 신학 학술제 참가 지원</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>신앙 공동체</h3>
+                        <ul>
+                            <li>온라인 채플 및 영성 세미나</li>
+                            <li>목회자 멘토링 라운드테이블</li>
+                            <li>지역 봉사 동아리 활동</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/graduate-business.html
+++ b/graduate-business.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>경영대학원 | GTCC</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <span class="department-hero__label" aria-label="대학원 과정">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                    Graduate Program
+                </span>
+                <h1>경영대학원</h1>
+                <p>
+                    경영대학원은 글로벌 시장에서 경쟁력 있는 전략가와 혁신 리더를 양성합니다.
+                    MBA, 경영학 석·박사 과정을 통해 데이터 기반 의사결정과 ESG 경영, 스타트업 생태계를 심층 탐구합니다.
+                </p>
+                <div class="department-meta">
+                    <span>학위과정: MBA · 경영학 석·박사</span>
+                    <span>소속: 대학원</span>
+                    <span>표준수업연한: 2~4년</span>
+                </div>
+            </div>
+            <nav class="department-tabs" aria-label="경영대학원 메뉴">
+                <div class="container">
+                    <a class="is-active" href="#overview">학과소개</a>
+                    <a href="#curriculum">교과과정</a>
+                    <a href="#career">진로 및 진출</a>
+                    <a href="#support">학생지원</a>
+                </div>
+            </nav>
+        </section>
+
+        <section id="overview" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>대학원 소개</h2>
+                    <p>
+                        경영전략, 디지털 전환, 재무/회계, 마케팅, 조직혁신 등 전문 트랙을 운영하며 실전 프로젝트를 중심으로 학습합니다.
+                        글로벌 기업과 협력한 실무형 프로그램과 네트워크를 제공합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">장학 · 등록 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">글로벌 비즈니스 전략</h3>
+                            <p class="department-list__subtitle">Global Business Strategy</p>
+                            <p class="department-list__body">글로벌 시장 분석, 경쟁전략, 국제경영 사례를 통해 전략적 의사결정 능력을 강화합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">데이터 &amp; 금융 분석</h3>
+                            <p class="department-list__subtitle">Data & Financial Analytics</p>
+                            <p class="department-list__body">재무모델링, 데이터 분석, AI 기반 경영 의사결정 도구를 활용합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">ESG · 스타트업 리더십</h3>
+                            <p class="department-list__subtitle">ESG & Startup Leadership</p>
+                            <p class="department-list__body">ESG 경영 전략과 스타트업 스케일업, 벤처투자 역량을 통합적으로 학습합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section">
+            <div class="container department-layout">
+                <div>
+                    <h2>교과과정 안내</h2>
+                    <p>
+                        MBA 기본과정, 전문 트랙 심화, 글로벌 프로젝트, 기업현장 실습으로 구성됩니다.
+                        케이스스터디, 디자인 씽킹, 액션러닝을 통해 전략 실행력을 강화합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>MBA Core</h3>
+                        <ul>
+                            <li>경영전략과 조직행동</li>
+                            <li>재무회계/관리회계</li>
+                            <li>마케팅 매니지먼트</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>전문 트랙</h3>
+                        <ul>
+                            <li>디지털 전환 &amp; 데이터 전략</li>
+                            <li>ESG·임팩트 비즈니스</li>
+                            <li>벤처투자와 스타트업 경영</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 적용</h3>
+                        <ul>
+                            <li>기업 컨설팅 프로젝트</li>
+                            <li>글로벌 경영 캠프</li>
+                            <li>스타트업 액셀러레이션 프로그램</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section">
+            <div class="container department-layout">
+                <h2>진로 및 진출 분야</h2>
+                <p>
+                    글로벌 기업 임원, 전략/재무 컨설턴트, 데이터/ESG 분석가, 스타트업 창업자, 벤처캐피탈리스트 등으로 진출합니다.
+                    해외 MBA, 박사과정 진학과 국제 비즈니스 커리어 확장을 지원합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>기업 경영</strong>
+                        <p>전략/마케팅/재무/HR 경영 리더</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>컨설팅/데이터</strong>
+                        <p>경영·재무 컨설턴트, 데이터 사이언스 리드, ESG 분석가</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>창업/투자</strong>
+                        <p>스타트업 창업자, VC/액셀러레이터, 글로벌 MBA &amp; Ph.D 진학</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학생 지원 프로그램</h2>
+                    <p>
+                        기업 멘토링, 글로벌 비즈니스 포럼, VC 네트워킹 세션을 운영합니다.
+                        케이스 컴피티션과 국제교환 프로그램으로 실무역량을 강화합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학술/실무 지원</h3>
+                        <ul>
+                            <li>MBA 케이스스터디 워크숍</li>
+                            <li>데이터 분석 &amp; 재무 모델링 부트캠프</li>
+                            <li>국제 비즈니스 콘퍼런스 참가 지원</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>비즈니스 네트워크</h3>
+                        <ul>
+                            <li>기업/동문 멘토십</li>
+                            <li>스타트업 피칭 데이</li>
+                            <li>글로벌 CEO 포럼</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/graduate-education.html
+++ b/graduate-education.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>교육대학원 | GTCC</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <span class="department-hero__label" aria-label="대학원 과정">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                    Graduate Program
+                </span>
+                <h1>교육대학원</h1>
+                <p>
+                    교육대학원은 학교와 평생교육 현장에서 필요한 전문 역량을 강화하여 미래형 교육 리더를 양성합니다.
+                    교육 연구와 수업 혁신, 교육행정 역량을 통합적으로 개발합니다.
+                </p>
+                <div class="department-meta">
+                    <span>학위과정: 석사(M.Ed) · 교육학 박사(Ed.D.)</span>
+                    <span>소속: 대학원</span>
+                    <span>표준수업연한: 2~4년</span>
+                </div>
+            </div>
+            <nav class="department-tabs" aria-label="교육대학원 메뉴">
+                <div class="container">
+                    <a class="is-active" href="#overview">학과소개</a>
+                    <a href="#curriculum">교과과정</a>
+                    <a href="#career">진로 및 진출</a>
+                    <a href="#support">학생지원</a>
+                </div>
+            </nav>
+        </section>
+
+        <section id="overview" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>대학원 소개</h2>
+                    <p>
+                        교육학 이론과 실제를 심층 탐구하고, 에듀테크, 평가, 교육행정 등 다양한 트랙을 운영합니다.
+                        현장 문제 해결형 연구와 교수학습 혁신 프로젝트를 통해 전문성을 높입니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">장학 · 등록 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">교육과정 설계 연구</h3>
+                            <p class="department-list__subtitle">Curriculum Design Research</p>
+                            <p class="department-list__body">차세대 교육과정 개발, 수업 설계 이론을 토대로 학습자 중심 수업 혁신을 추진합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">에듀테크와 데이터 분석</h3>
+                            <p class="department-list__subtitle">EdTech & Learning Analytics</p>
+                            <p class="department-list__body">AI 기반 학습분석, 온라인 학습환경 설계, 교육 데이터 활용법을 학습합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">교육 리더십 &amp; 정책</h3>
+                            <p class="department-list__subtitle">Educational Leadership & Policy</p>
+                            <p class="department-list__body">교육 행정, 정책 분석, 조직 변화 관리를 통해 학교와 지역사회의 교육 혁신을 이끕니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section">
+            <div class="container department-layout">
+                <div>
+                    <h2>교과과정 안내</h2>
+                    <p>
+                        교육학 이론, 연구방법론, 전공별 심화, 현장 기반 프로젝트로 구성됩니다.
+                        액션리서치와 캡스톤 프로젝트를 통해 실무 적용 능력을 강화합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>공통 필수</h3>
+                        <ul>
+                            <li>교육철학 및 이론</li>
+                            <li>교육연구 방법론</li>
+                            <li>학습자 분석과 평가</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>트랙 심화</h3>
+                        <ul>
+                            <li>디지털 교수학습 전략</li>
+                            <li>교육행정과 리더십</li>
+                            <li>특수/평생교육 프로젝트</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 적용</h3>
+                        <ul>
+                            <li>교육기관 액션리서치</li>
+                            <li>수업 혁신 캡스톤</li>
+                            <li>국내외 교육연수</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section">
+            <div class="container department-layout">
+                <h2>진로 및 진출 분야</h2>
+                <p>
+                    학교 관리자, 교육과정 전문가, 에듀테크 기획자, 교육정책 연구원, 평생교육기관 운영자 등으로 진출합니다.
+                    교육학 박사과정, 국제 교육 관련 연구기관 등으로의 진학이 가능합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>학교 현장</strong>
+                        <p>교감·교장 등 교육 리더, 수업 혁신 코디네이터</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>교육 산업</strong>
+                        <p>에듀테크 기획자, 콘텐츠 개발자, 교육컨설턴트</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>연구/정책</strong>
+                        <p>교육정책 연구원, 국제교육 NGO, 교육행정 박사과정</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학생 지원 프로그램</h2>
+                    <p>
+                        현장 멘토링, 수업코칭 랩, 글로벌 교육연수 프로그램을 운영합니다.
+                        연구장학금과 교육 혁신 펠로우십으로 전문성 향상을 지원합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학술/현장 지원</h3>
+                        <ul>
+                            <li>논문 설계 워크숍</li>
+                            <li>수업컨설팅 &amp; 코칭</li>
+                            <li>국제 교육학회 참가 지원</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>교육 네트워크</h3>
+                        <ul>
+                            <li>교육 리더십 포럼</li>
+                            <li>수업혁신 커뮤니티</li>
+                            <li>글로벌 교육 교류 프로젝트</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/graduate-theology.html
+++ b/graduate-theology.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>신학대학원 | GTCC</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <span class="department-hero__label" aria-label="대학원 과정">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                    Graduate Program
+                </span>
+                <h1>신학대학원</h1>
+                <p>
+                    신학대학원은 신학적 탐구와 목회 실천의 심화를 통해 교회와 사회를 섬길 수 있는 전문 사역자와 학자를 양성합니다.
+                    연구 중심 커리큘럼과 사역 현장을 연결하여 학문과 실천을 통합합니다.
+                </p>
+                <div class="department-meta">
+                    <span>학위과정: 석사(MDiv/MTS) · 박사(Th.D.)</span>
+                    <span>소속: 대학원</span>
+                    <span>표준수업연한: 2~4년</span>
+                </div>
+            </div>
+            <nav class="department-tabs" aria-label="신학대학원 메뉴">
+                <div class="container">
+                    <a class="is-active" href="#overview">학과소개</a>
+                    <a href="#curriculum">교과과정</a>
+                    <a href="#career">진로 및 진출</a>
+                    <a href="#support">학생지원</a>
+                </div>
+            </nav>
+        </section>
+
+        <section id="overview" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>대학원 소개</h2>
+                    <p>
+                        신학대학원은 성서학, 조직신학, 역사신학, 실천신학 등 전 전공을 심화 연구하며, 전문 목회자와 신학자를 배출합니다.
+                        학제 간 연구와 글로벌 신학 네트워크를 통해 시대적 현안에 응답하는 신학적 통찰을 제공합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">장학 · 등록 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">성서 원문 연구</h3>
+                            <p class="department-list__subtitle">Biblical Languages & Exegesis</p>
+                            <p class="department-list__body">히브리어·헬라어 심화와 텍스트 비평을 통해 성서 해석의 학문적 깊이를 확장합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">목회 리더십과 영성</h3>
+                            <p class="department-list__subtitle">Advanced Pastoral Leadership</p>
+                            <p class="department-list__body">설교학, 영성 지도력, 교회 리더십 세미나를 통해 현장 중심 리더십을 강화합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">신학 연구와 실천</h3>
+                            <p class="department-list__subtitle">Research & Ministry Integration</p>
+                            <p class="department-list__body">신학 연구 방법론과 목회 현장 연구를 결합하여 실천적 신학을 개발합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section">
+            <div class="container department-layout">
+                <div>
+                    <h2>교과과정 안내</h2>
+                    <p>
+                        석·박사 과정은 연구 세미나, 독립 연구, 목회 인턴십으로 구성되며 학문과 사역의 통합을 목표로 합니다.
+                        집중 세미나와 코호트 학습으로 국제 신학 담론과 네트워크를 경험합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>공통 핵심</h3>
+                        <ul>
+                            <li>성서신학 연구세미나</li>
+                            <li>조직신학 방법론</li>
+                            <li>신학 연구윤리</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>전공 심화</h3>
+                        <ul>
+                            <li>구약/신약 주제 연구</li>
+                            <li>선교·목회 전문 세미나</li>
+                            <li>신학과 문화 연구</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>사역·연구 연계</h3>
+                        <ul>
+                            <li>목회 인턴십 &amp; 감독</li>
+                            <li>현장 기반 액션리서치</li>
+                            <li>국제 신학 컨퍼런스 참가</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section">
+            <div class="container department-layout">
+                <h2>진로 및 진출 분야</h2>
+                <p>
+                    졸업생은 담임/부목회자, 선교전략가, 신학 연구자, 신학교 교수, NGO/병원/군목 사역 등으로 진출합니다.
+                    국제 신학 학술지 기고와 박사 후 연구를 위한 기반을 제공합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>목회/선교 분야</strong>
+                        <p>교단 담임·부목사, 전문 선교사, 군·병원·교정 사역자</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>신학 연구/교육</strong>
+                        <p>신학교 교수, 연구소 연구원, 신학 출판/미디어</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>전문 사역</strong>
+                        <p>영성 지도자, 목회 상담가, NGO/공공신학 프로젝트</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학생 지원 프로그램</h2>
+                    <p>
+                        교수진 멘토링, 목회 코호트, 연구비 지원 프로그램을 통해 학문과 사역을 동시에 지원합니다.
+                        글로벌 파트너 신학교와의 교환 세미나로 국제적 관점을 확장합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학술/사역 지원</h3>
+                        <ul>
+                            <li>석·박사 논문 세미나</li>
+                            <li>목회 코칭 &amp; 영성 지도</li>
+                            <li>국제 학술대회 참가 지원</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>사역 네트워크</h3>
+                        <ul>
+                            <li>목회자·동문 네트워킹</li>
+                            <li>글로벌 미션 라운드테이블</li>
+                            <li>지역사회 사역 프로젝트</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add local detail pages for each undergraduate department and graduate school menu item and hook them into the 학과소개 mega menu
- build reusable department page sections featuring hero, overview, curriculum, career, and support blocks for consistent layouts
- style the new department template components with hero, tab, list, and card treatments

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5c6c864c0833284fc6c6be550a9f3