### PR TITLE
Add faculty highlight cards to department hero sections

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -970,6 +970,19 @@ body.theme-dark .dark-mode-toggle {
     gap: 2rem;
 }
 
+.department-hero__layout {
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: minmax(0, 1.8fr) minmax(0, 1fr);
+    align-items: start;
+}
+
+.department-hero__summary {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
 .department-hero__label {
     display: inline-flex;
     align-items: center;
@@ -1052,6 +1065,113 @@ body.theme-dark .dark-mode-toggle {
     background: var(--primary);
     color: var(--white);
     box-shadow: 0 12px 24px rgba(58, 111, 247, 0.25);
+}
+
+.department-hero__faculty {
+    background: var(--white);
+    border-radius: 1.5rem;
+    padding: 1.75rem 1.85rem;
+    box-shadow: 0 18px 38px rgba(17, 29, 63, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.department-hero__faculty h2 {
+    font-size: 1.35rem;
+    margin: 0;
+}
+
+.department-hero__faculty-intro {
+    color: var(--muted);
+    font-size: 0.98rem;
+    margin: 0;
+    line-height: 1.7;
+}
+
+.department-hero__faculty-list {
+    display: grid;
+    gap: 1.1rem;
+}
+
+.faculty-card {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.1rem 1.25rem;
+    border-radius: 1.25rem;
+    background: rgba(58, 111, 247, 0.08);
+}
+
+.faculty-card:nth-of-type(2n) {
+    background: rgba(18, 184, 134, 0.08);
+}
+
+.faculty-card:nth-of-type(3n) {
+    background: rgba(255, 123, 90, 0.08);
+}
+
+.faculty-card__photo {
+    width: 4.25rem;
+    height: 4.25rem;
+    border-radius: 1.1rem;
+    overflow: hidden;
+    flex-shrink: 0;
+    box-shadow: 0 12px 24px rgba(17, 29, 63, 0.12);
+}
+
+.faculty-card__photo img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.faculty-card__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.faculty-card__name {
+    font-weight: 700;
+    font-size: 1.05rem;
+    margin: 0;
+}
+
+.faculty-card__role {
+    margin: 0;
+    color: var(--primary-dark);
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.faculty-card__focus {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+@media (max-width: 960px) {
+    .department-hero__layout {
+        grid-template-columns: 1fr;
+    }
+
+    .department-hero__faculty {
+        padding: 1.5rem;
+    }
+}
+
+@media (max-width: 640px) {
+    .faculty-card {
+        align-items: flex-start;
+    }
+
+    .faculty-card__photo {
+        width: 3.6rem;
+        height: 3.6rem;
+        border-radius: 0.9rem;
+    }
 }
 
 .department-section {

--- a/college-business.html
+++ b/college-business.html
@@ -15,19 +15,49 @@
     <main>
         <section class="department-hero">
             <div class="container">
-                <span class="department-hero__label" aria-label="대학 과정">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
-                    Undergraduate Program
-                </span>
-                <h1>경영학과</h1>
-                <p>
-                    경영학과는 글로벌 비즈니스 환경에서 전략적으로 사고하고 실행할 수 있는 경영 리더를 양성합니다.
-                    데이터 기반 의사결정 능력과 스타트업/ESG 경영 역량을 함께 기릅니다.
-                </p>
-                <div class="department-meta">
-                    <span>학위과정: 학사(BBA)</span>
-                    <span>소속: 대학교</span>
-                    <span>표준수업연한: 4년</span>
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="대학 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Undergraduate Program
+                        </span>
+                        <h1>경영학과</h1>
+                        <p>
+                            경영학과는 글로벌 비즈니스 환경에서 전략적으로 사고하고 실행할 수 있는 경영 리더를 양성합니다.
+                            데이터 기반 의사결정 능력과 스타트업/ESG 경영 역량을 함께 기릅니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>학위과정: 학사(BBA)</span>
+                            <span>소속: 대학교</span>
+                            <span>표준수업연한: 4년</span>
+                        </div>
+                    </div>
+                    <aside class="department-hero__faculty" aria-label="대표 교수진">
+                        <h2>대표 교수진</h2>
+                        <p class="department-hero__faculty-intro">실전 비즈니스 경험과 데이터 전문성을 갖춘 교수진이 경영 전략 수립과 창업 역량을 함께 이끕니다.</p>
+                        <div class="department-hero__faculty-list">
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="김도현 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">김도현 교수</p>
+                                    <p class="faculty-card__role">전략경영</p>
+                                    <p class="faculty-card__focus">디지털 전환 전략과 스타트업 멘토링을 중심으로 실무형 프로젝트를 지도합니다.</p>
+                                </div>
+                            </article>
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZTlmOGY1Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMxMmI4ODYiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMGI1MTNkIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMxMmI4ODYiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="박서윤 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">박서윤 교수</p>
+                                    <p class="faculty-card__role">재무 · 핀테크</p>
+                                    <p class="faculty-card__focus">데이터 기반 투자 분석과 ESG 금융 전략을 연구하며 학생 창업을 지원합니다.</p>
+                                </div>
+                            </article>
+                        </div>
+                    </aside>
                 </div>
             </div>
             <nav class="department-tabs" aria-label="경영학과 메뉴">

--- a/college-christian-education.html
+++ b/college-christian-education.html
@@ -15,19 +15,49 @@
     <main>
         <section class="department-hero">
             <div class="container">
-                <span class="department-hero__label" aria-label="대학 과정">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
-                    Undergraduate Program
-                </span>
-                <h1>기독교교육학과</h1>
-                <p>
-                    기독교교육학과는 신앙과 교육학을 융합하여 다음 세대와 지역사회에 영향력을 발휘할 교육 사역자를 양성합니다.
-                    교육공학 기반의 온라인 콘텐츠 설계 역량과 목회 현장의 실습 경험을 균형 있게 제공합니다.
-                </p>
-                <div class="department-meta">
-                    <span>학위과정: 학사(BA)</span>
-                    <span>소속: 대학교</span>
-                    <span>표준수업연한: 4년</span>
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="대학 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Undergraduate Program
+                        </span>
+                        <h1>기독교교육학과</h1>
+                        <p>
+                            기독교교육학과는 신앙과 교육학을 융합하여 다음 세대와 지역사회에 영향력을 발휘할 교육 사역자를 양성합니다.
+                            교육공학 기반의 온라인 콘텐츠 설계 역량과 목회 현장의 실습 경험을 균형 있게 제공합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>학위과정: 학사(BA)</span>
+                            <span>소속: 대학교</span>
+                            <span>표준수업연한: 4년</span>
+                        </div>
+                    </div>
+                    <aside class="department-hero__faculty" aria-label="대표 교수진">
+                        <h2>대표 교수진</h2>
+                        <p class="department-hero__faculty-intro">영성과 교육학 전문성을 겸비한 교수진이 디지털 세대에 맞춘 교육 콘텐츠와 돌봄 사역을 설계합니다.</p>
+                        <div class="department-hero__faculty-list">
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZTlmOGY1Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMxMmI4ODYiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMGI1MTNkIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMxMmI4ODYiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="박은총 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">박은총 교수</p>
+                                    <p class="faculty-card__role">기독교교육학</p>
+                                    <p class="faculty-card__focus">디지털 세대 맞춤 성경교육 콘텐츠와 교육 커리큘럼 설계를 연구합니다.</p>
+                                </div>
+                            </article>
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="Grace Kim 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">Grace Kim 교수</p>
+                                    <p class="faculty-card__role">영성지도</p>
+                                    <p class="faculty-card__focus">온라인 예배와 공동체 돌봄 사역을 연계한 영성 교육 프로그램을 개발합니다.</p>
+                                </div>
+                            </article>
+                        </div>
+                    </aside>
                 </div>
             </div>
             <nav class="department-tabs" aria-label="기독교교육학과 메뉴">

--- a/college-counseling.html
+++ b/college-counseling.html
@@ -15,19 +15,49 @@
     <main>
         <section class="department-hero">
             <div class="container">
-                <span class="department-hero__label" aria-label="대학 과정">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
-                    Undergraduate Program
-                </span>
-                <h1>상담학과</h1>
-                <p>
-                    상담학과는 심리학과 상담 이론을 바탕으로 개인과 공동체의 변화를 돕는 전문 상담가를 양성합니다.
-                    온라인 기반 사례관리와 대면 슈퍼비전을 병행하여 실무 역량을 강화합니다.
-                </p>
-                <div class="department-meta">
-                    <span>학위과정: 학사(BA)</span>
-                    <span>소속: 대학교</span>
-                    <span>표준수업연한: 4년</span>
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="대학 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Undergraduate Program
+                        </span>
+                        <h1>상담학과</h1>
+                        <p>
+                            상담학과는 심리학과 상담 이론을 바탕으로 개인과 공동체의 변화를 돕는 전문 상담가를 양성합니다.
+                            온라인 기반 사례관리와 대면 슈퍼비전을 병행하여 실무 역량을 강화합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>학위과정: 학사(BA)</span>
+                            <span>소속: 대학교</span>
+                            <span>표준수업연한: 4년</span>
+                        </div>
+                    </div>
+                    <aside class="department-hero__faculty" aria-label="대표 교수진">
+                        <h2>대표 교수진</h2>
+                        <p class="department-hero__faculty-intro">임상과 코칭 경험을 갖춘 교수진이 다양한 연령과 조직을 위한 맞춤형 상담 프로그램을 지도합니다.</p>
+                        <div class="department-hero__faculty-list">
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWFmMGZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMzYTZmZjciLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMWYyYTQ0IiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMzYTZmZjciIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="이수연 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">이수연 교수</p>
+                                    <p class="faculty-card__role">상담심리</p>
+                                    <p class="faculty-card__focus">청소년 정서 지원과 가족 상담 프로그램 개발을 통해 현장 중심 역량을 강화합니다.</p>
+                                </div>
+                            </article>
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="정민우 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">정민우 교수</p>
+                                    <p class="faculty-card__role">코칭심리</p>
+                                    <p class="faculty-card__focus">진로 코칭과 조직 상담 프로젝트를 운영하며 실무형 상담 기법을 전수합니다.</p>
+                                </div>
+                            </article>
+                        </div>
+                    </aside>
                 </div>
             </div>
             <nav class="department-tabs" aria-label="상담학과 메뉴">

--- a/college-customs.html
+++ b/college-customs.html
@@ -15,19 +15,49 @@
     <main>
         <section class="department-hero">
             <div class="container">
-                <span class="department-hero__label" aria-label="대학 과정">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
-                    Undergraduate Program
-                </span>
-                <h1>관세학과</h1>
-                <p>
-                    관세학과는 글로벌 무역 현장에서 필요한 통관, 관세평가, 무역규범 전문 인력을 양성합니다.
-                    실무 중심 교육과 국제 교류를 통해 통상 전문가로 성장할 수 있습니다.
-                </p>
-                <div class="department-meta">
-                    <span>학위과정: 학사(BBA)</span>
-                    <span>소속: 대학교</span>
-                    <span>표준수업연한: 4년</span>
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="대학 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Undergraduate Program
+                        </span>
+                        <h1>관세학과</h1>
+                        <p>
+                            관세학과는 글로벌 무역 현장에서 필요한 통관, 관세평가, 무역규범 전문 인력을 양성합니다.
+                            실무 중심 교육과 국제 교류를 통해 통상 전문가로 성장할 수 있습니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>학위과정: 학사(BBA)</span>
+                            <span>소속: 대학교</span>
+                            <span>표준수업연한: 4년</span>
+                        </div>
+                    </div>
+                    <aside class="department-hero__faculty" aria-label="대표 교수진">
+                        <h2>대표 교수진</h2>
+                        <p class="department-hero__faculty-intro">국제 통상 실무와 관세 행정 전문가들이 FTA 통관 전략과 무역 리스크 대응 역량을 교육합니다.</p>
+                        <div class="department-hero__faculty-list">
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWFmMGZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMzYTZmZjciLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMWYyYTQ0IiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMzYTZmZjciIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="문지호 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">문지호 교수</p>
+                                    <p class="faculty-card__role">관세행정</p>
+                                    <p class="faculty-card__focus">FTA 통관 전략과 관세쟁송 컨설팅 사례를 기반으로 실무 대응 능력을 강화합니다.</p>
+                                </div>
+                            </article>
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="배소영 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">배소영 교수</p>
+                                    <p class="faculty-card__role">무역실무</p>
+                                    <p class="faculty-card__focus">글로벌 공급망 리스크 관리와 통상 협상 사례를 중심으로 전략적 무역 실무를 지도합니다.</p>
+                                </div>
+                            </article>
+                        </div>
+                    </aside>
                 </div>
             </div>
             <nav class="department-tabs" aria-label="관세학과 메뉴">

--- a/college-english.html
+++ b/college-english.html
@@ -15,19 +15,49 @@
     <main>
         <section class="department-hero">
             <div class="container">
-                <span class="department-hero__label" aria-label="대학 과정">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
-                    Undergraduate Program
-                </span>
-                <h1>영어학과</h1>
-                <p>
-                    영어학과는 글로벌 커뮤니케이션 능력과 비즈니스 실무 역량을 갖춘 전문 인재를 양성합니다.
-                    언어학과 문학, 번역, 디지털 콘텐츠 제작 등 폭넓은 교육을 통해 국제 무대에서 활약할 수 있는 역량을 키웁니다.
-                </p>
-                <div class="department-meta">
-                    <span>학위과정: 학사(BA)</span>
-                    <span>소속: 대학교</span>
-                    <span>표준수업연한: 4년</span>
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="대학 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Undergraduate Program
+                        </span>
+                        <h1>영어학과</h1>
+                        <p>
+                            영어학과는 글로벌 커뮤니케이션 능력과 비즈니스 실무 역량을 갖춘 전문 인재를 양성합니다.
+                            언어학과 문학, 번역, 디지털 콘텐츠 제작 등 폭넓은 교육을 통해 국제 무대에서 활약할 수 있는 역량을 키웁니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>학위과정: 학사(BA)</span>
+                            <span>소속: 대학교</span>
+                            <span>표준수업연한: 4년</span>
+                        </div>
+                    </div>
+                    <aside class="department-hero__faculty" aria-label="대표 교수진">
+                        <h2>대표 교수진</h2>
+                        <p class="department-hero__faculty-intro">국제 경험과 실무 전문성을 갖춘 교수진이 학생들의 글로벌 커뮤니케이션 역량을 키웁니다.</p>
+                        <div class="department-hero__faculty-list">
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWFmMGZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMzYTZmZjciLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMWYyYTQ0IiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMzYTZmZjciIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="민지연 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">민지연 교수</p>
+                                    <p class="faculty-card__role">응용언어학 · TESOL</p>
+                                    <p class="faculty-card__focus">디지털 기반 영어교육 방법 연구와 다문화 수업 설계를 담당합니다.</p>
+                                </div>
+                            </article>
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="Ethan Choi 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">Ethan Choi 교수</p>
+                                    <p class="faculty-card__role">국제비즈니스 커뮤니케이션</p>
+                                    <p class="faculty-card__focus">글로벌 마케팅 커뮤니케이션 프로젝트를 지도하며 실무형 포트폴리오를 지원합니다.</p>
+                                </div>
+                            </article>
+                        </div>
+                    </aside>
                 </div>
             </div>
             <nav class="department-tabs" aria-label="영어학과 메뉴">

--- a/college-music-education.html
+++ b/college-music-education.html
@@ -15,19 +15,49 @@
     <main>
         <section class="department-hero">
             <div class="container">
-                <span class="department-hero__label" aria-label="대학 과정">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
-                    Undergraduate Program
-                </span>
-                <h1>음악교육학과</h1>
-                <p>
-                    음악교육학과는 연주와 이론, 교육학을 통합하여 창의적이고 감성적인 음악 교육 전문가를 양성합니다.
-                    디지털 음향 기술과 문화예술교육 프로그램 설계 역량을 함께 갖춘 융합형 인재를 키웁니다.
-                </p>
-                <div class="department-meta">
-                    <span>학위과정: 학사(BMusEd)</span>
-                    <span>소속: 대학교</span>
-                    <span>표준수업연한: 4년</span>
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="대학 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Undergraduate Program
+                        </span>
+                        <h1>음악교육학과</h1>
+                        <p>
+                            음악교육학과는 연주와 이론, 교육학을 통합하여 창의적이고 감성적인 음악 교육 전문가를 양성합니다.
+                            디지털 음향 기술과 문화예술교육 프로그램 설계 역량을 함께 갖춘 융합형 인재를 키웁니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>학위과정: 학사(BMusEd)</span>
+                            <span>소속: 대학교</span>
+                            <span>표준수업연한: 4년</span>
+                        </div>
+                    </div>
+                    <aside class="department-hero__faculty" aria-label="대표 교수진">
+                        <h2>대표 교수진</h2>
+                        <p class="department-hero__faculty-intro">연주와 교육 현장을 넘나드는 교수진이 창의 융합형 음악 수업과 실용음악 제작 역량을 길러줍니다.</p>
+                        <div class="department-hero__faculty-list">
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZTlmOGY1Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMxMmI4ODYiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMGI1MTNkIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMxMmI4ODYiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="한세린 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">한세린 교수</p>
+                                    <p class="faculty-card__role">음악교육학</p>
+                                    <p class="faculty-card__focus">창의 융합형 음악 수업 디자인과 프로젝트 기반 학습을 연구합니다.</p>
+                                </div>
+                            </article>
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="David Park 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">David Park 교수</p>
+                                    <p class="faculty-card__role">실용음악</p>
+                                    <p class="faculty-card__focus">디지털 사운드 프로덕션과 공연 기획을 결합한 실무 프로젝트를 지도합니다.</p>
+                                </div>
+                            </article>
+                        </div>
+                    </aside>
                 </div>
             </div>
             <nav class="department-tabs" aria-label="음악교육학과 메뉴">

--- a/college-physical-education.html
+++ b/college-physical-education.html
@@ -15,19 +15,49 @@
     <main>
         <section class="department-hero">
             <div class="container">
-                <span class="department-hero__label" aria-label="대학 과정">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
-                    Undergraduate Program
-                </span>
-                <h1>체육교육학과</h1>
-                <p>
-                    체육교육학과는 스포츠 과학과 교육학을 융합하여 건강한 공동체를 이끄는 체육 교사와 전문 코치를 양성합니다.
-                    최신 디지털 트레이닝 기법과 현장 실습을 통해 체육 지도 역량과 스포츠 콘텐츠 제작 능력을 기릅니다.
-                </p>
-                <div class="department-meta">
-                    <span>학위과정: 학사(BPE)</span>
-                    <span>소속: 대학교</span>
-                    <span>표준수업연한: 4년</span>
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="대학 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Undergraduate Program
+                        </span>
+                        <h1>체육교육학과</h1>
+                        <p>
+                            체육교육학과는 스포츠 과학과 교육학을 융합하여 건강한 공동체를 이끄는 체육 교사와 전문 코치를 양성합니다.
+                            최신 디지털 트레이닝 기법과 현장 실습을 통해 체육 지도 역량과 스포츠 콘텐츠 제작 능력을 기릅니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>학위과정: 학사(BPE)</span>
+                            <span>소속: 대학교</span>
+                            <span>표준수업연한: 4년</span>
+                        </div>
+                    </div>
+                    <aside class="department-hero__faculty" aria-label="대표 교수진">
+                        <h2>대표 교수진</h2>
+                        <p class="department-hero__faculty-intro">스포츠 현장과 연구를 넘나드는 교수진이 선수 트레이닝과 건강운동관리 역량을 체계적으로 지도합니다.</p>
+                        <div class="department-hero__faculty-list">
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWFmMGZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMzYTZmZjciLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMWYyYTQ0IiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMzYTZmZjciIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="최강민 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">최강민 교수</p>
+                                    <p class="faculty-card__role">스포츠과학</p>
+                                    <p class="faculty-card__focus">피지컬 데이터 분석과 선수 트레이닝 프로그램 설계를 중심으로 경쟁력을 높입니다.</p>
+                                </div>
+                            </article>
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="윤다은 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">윤다은 교수</p>
+                                    <p class="faculty-card__role">건강운동관리</p>
+                                    <p class="faculty-card__focus">생활체육 코칭과 체력관리 프로그램으로 지역사회 건강증진 프로젝트를 이끕니다.</p>
+                                </div>
+                            </article>
+                        </div>
+                    </aside>
                 </div>
             </div>
             <nav class="department-tabs" aria-label="체육교육학과 메뉴">

--- a/college-public-administration.html
+++ b/college-public-administration.html
@@ -15,19 +15,49 @@
     <main>
         <section class="department-hero">
             <div class="container">
-                <span class="department-hero__label" aria-label="대학 과정">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
-                    Undergraduate Program
-                </span>
-                <h1>행정학과</h1>
-                <p>
-                    행정학과는 공공정책 기획과 행정 운영 능력을 갖춘 공공 리더를 양성합니다.
-                    데이터 기반 행정과 디지털 거버넌스 역량을 강화하여 미래 지향적 행정 전문가를 배출합니다.
-                </p>
-                <div class="department-meta">
-                    <span>학위과정: 학사(BA)</span>
-                    <span>소속: 대학교</span>
-                    <span>표준수업연한: 4년</span>
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="대학 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Undergraduate Program
+                        </span>
+                        <h1>행정학과</h1>
+                        <p>
+                            행정학과는 공공정책 기획과 행정 운영 능력을 갖춘 공공 리더를 양성합니다.
+                            데이터 기반 행정과 디지털 거버넌스 역량을 강화하여 미래 지향적 행정 전문가를 배출합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>학위과정: 학사(BA)</span>
+                            <span>소속: 대학교</span>
+                            <span>표준수업연한: 4년</span>
+                        </div>
+                    </div>
+                    <aside class="department-hero__faculty" aria-label="대표 교수진">
+                        <h2>대표 교수진</h2>
+                        <p class="department-hero__faculty-intro">공공정책 분석과 도시 행정 분야 전문가들이 데이터 기반 행정 혁신을 이끄는 프로젝트를 지도합니다.</p>
+                        <div class="department-hero__faculty-list">
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWFmMGZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMzYTZmZjciLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMWYyYTQ0IiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMzYTZmZjciIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="한승우 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">한승우 교수</p>
+                                    <p class="faculty-card__role">공공정책</p>
+                                    <p class="faculty-card__focus">데이터 기반 정책평가와 정부 혁신 전략을 연구하며 행정 빅데이터 분석을 지도합니다.</p>
+                                </div>
+                            </article>
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZTlmOGY1Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMxMmI4ODYiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMGI1MTNkIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMxMmI4ODYiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="정리아 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">정리아 교수</p>
+                                    <p class="faculty-card__role">도시행정</p>
+                                    <p class="faculty-card__focus">스마트시티 거버넌스와 주민참여 행정을 바탕으로 도시 혁신 정책을 설계합니다.</p>
+                                </div>
+                            </article>
+                        </div>
+                    </aside>
                 </div>
             </div>
             <nav class="department-tabs" aria-label="행정학과 메뉴">

--- a/college-real-estate.html
+++ b/college-real-estate.html
@@ -15,19 +15,49 @@
     <main>
         <section class="department-hero">
             <div class="container">
-                <span class="department-hero__label" aria-label="대학 과정">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
-                    Undergraduate Program
-                </span>
-                <h1>부동산학과</h1>
-                <p>
-                    부동산학과는 부동산 개발, 금융, 자산관리를 통합적으로 학습하여 부동산 전문 경영인을 양성합니다.
-                    데이터 분석과 법제 이해를 바탕으로 지속가능한 도시와 주거환경을 설계할 수 있는 능력을 키웁니다.
-                </p>
-                <div class="department-meta">
-                    <span>학위과정: 학사(BBA)</span>
-                    <span>소속: 대학교</span>
-                    <span>표준수업연한: 4년</span>
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="대학 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Undergraduate Program
+                        </span>
+                        <h1>부동산학과</h1>
+                        <p>
+                            부동산학과는 부동산 개발, 금융, 자산관리를 통합적으로 학습하여 부동산 전문 경영인을 양성합니다.
+                            데이터 분석과 법제 이해를 바탕으로 지속가능한 도시와 주거환경을 설계할 수 있는 능력을 키웁니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>학위과정: 학사(BBA)</span>
+                            <span>소속: 대학교</span>
+                            <span>표준수업연한: 4년</span>
+                        </div>
+                    </div>
+                    <aside class="department-hero__faculty" aria-label="대표 교수진">
+                        <h2>대표 교수진</h2>
+                        <p class="department-hero__faculty-intro">부동산 금융과 자산평가 분야 전문가들이 도시재생과 투자 전략 프로젝트를 밀착 지도합니다.</p>
+                        <div class="department-hero__faculty-list">
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWFmMGZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMzYTZmZjciLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMWYyYTQ0IiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMzYTZmZjciIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="이상훈 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">이상훈 교수</p>
+                                    <p class="faculty-card__role">부동산금융</p>
+                                    <p class="faculty-card__focus">도시재생 투자 전략과 자산관리 모델을 설계하며 빅데이터 기반 분석을 지도합니다.</p>
+                                </div>
+                            </article>
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="김현주 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">김현주 교수</p>
+                                    <p class="faculty-card__role">부동산 공시·평가</p>
+                                    <p class="faculty-card__focus">부동산 빅데이터 가치 분석과 공공·민간 평가 실무를 아우르는 사례 연구를 제공합니다.</p>
+                                </div>
+                            </article>
+                        </div>
+                    </aside>
                 </div>
             </div>
             <nav class="department-tabs" aria-label="부동산학과 메뉴">

--- a/college-social-welfare.html
+++ b/college-social-welfare.html
@@ -15,19 +15,49 @@
     <main>
         <section class="department-hero">
             <div class="container">
-                <span class="department-hero__label" aria-label="대학 과정">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
-                    Undergraduate Program
-                </span>
-                <h1>복지학과</h1>
-                <p>
-                    복지학과는 사회적 약자를 지원하고 지역사회 복지를 증진할 전문 사회복지사를 양성합니다.
-                    정책 이해와 사례관리, 지역사회 개발을 통합적으로 학습합니다.
-                </p>
-                <div class="department-meta">
-                    <span>학위과정: 학사(BA)</span>
-                    <span>소속: 대학교</span>
-                    <span>표준수업연한: 4년</span>
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="대학 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Undergraduate Program
+                        </span>
+                        <h1>복지학과</h1>
+                        <p>
+                            복지학과는 사회적 약자를 지원하고 지역사회 복지를 증진할 전문 사회복지사를 양성합니다.
+                            정책 이해와 사례관리, 지역사회 개발을 통합적으로 학습합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>학위과정: 학사(BA)</span>
+                            <span>소속: 대학교</span>
+                            <span>표준수업연한: 4년</span>
+                        </div>
+                    </div>
+                    <aside class="department-hero__faculty" aria-label="대표 교수진">
+                        <h2>대표 교수진</h2>
+                        <p class="department-hero__faculty-intro">사회정책과 현장 상담 경험을 갖춘 교수진이 지역사회와 연계된 실천 중심 교육을 진행합니다.</p>
+                        <div class="department-hero__faculty-list">
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZTlmOGY1Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMxMmI4ODYiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMGI1MTNkIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMxMmI4ODYiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="장민석 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">장민석 교수</p>
+                                    <p class="faculty-card__role">사회복지정책</p>
+                                    <p class="faculty-card__focus">취약계층 지원 정책 평가와 지역사회 복지 거버넌스 구축을 연구합니다.</p>
+                                </div>
+                            </article>
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="오하늘 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">오하늘 교수</p>
+                                    <p class="faculty-card__role">임상사회복지</p>
+                                    <p class="faculty-card__focus">트라우마 회복 프로그램과 가족 상담 사례 연구를 통해 현장 대응력을 높입니다.</p>
+                                </div>
+                            </article>
+                        </div>
+                    </aside>
                 </div>
             </div>
             <nav class="department-tabs" aria-label="복지학과 메뉴">

--- a/college-theology.html
+++ b/college-theology.html
@@ -15,19 +15,49 @@
     <main>
         <section class="department-hero">
             <div class="container">
-                <span class="department-hero__label" aria-label="대학 과정">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
-                    Undergraduate Program
-                </span>
-                <h1>신학과</h1>
-                <p>
-                    신학과는 성서와 교리를 체계적으로 탐구하며 시대적 요청에 응답할 수 있는 신앙 리더를 양성합니다.
-                    영성과 학문성을 겸비한 목회자와 신학자를 목표로 성서 해석, 역사·조직신학, 실천신학을 균형 있게 다룹니다.
-                </p>
-                <div class="department-meta">
-                    <span>학위과정: 학사(BA)</span>
-                    <span>소속: 대학교</span>
-                    <span>표준수업연한: 4년</span>
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="대학 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Undergraduate Program
+                        </span>
+                        <h1>신학과</h1>
+                        <p>
+                            신학과는 성서와 교리를 체계적으로 탐구하며 시대적 요청에 응답할 수 있는 신앙 리더를 양성합니다.
+                            영성과 학문성을 겸비한 목회자와 신학자를 목표로 성서 해석, 역사·조직신학, 실천신학을 균형 있게 다룹니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>학위과정: 학사(BA)</span>
+                            <span>소속: 대학교</span>
+                            <span>표준수업연한: 4년</span>
+                        </div>
+                    </div>
+                    <aside class="department-hero__faculty" aria-label="대표 교수진">
+                        <h2>대표 교수진</h2>
+                        <p class="department-hero__faculty-intro">신학 전통과 현대 사역 경험을 갖춘 교수진이 영성, 선교, 상담을 아우르는 통합 교육을 제공합니다.</p>
+                        <div class="department-hero__faculty-list">
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWFmMGZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMzYTZmZjciLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMWYyYTQ0IiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMzYTZmZjciIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="이요한 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">이요한 교수</p>
+                                    <p class="faculty-card__role">성서신학</p>
+                                    <p class="faculty-card__focus">성서 해석과 목회 상담을 통합한 교육으로 현장 중심의 신학 적용을 안내합니다.</p>
+                                </div>
+                            </article>
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="서지은 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">서지은 교수</p>
+                                    <p class="faculty-card__role">선교학</p>
+                                    <p class="faculty-card__focus">글로벌 선교 전략과 지역사회 봉사를 연계하는 혁신적 사역 모델을 연구합니다.</p>
+                                </div>
+                            </article>
+                        </div>
+                    </aside>
                 </div>
             </div>
             <nav class="department-tabs" aria-label="신학과 메뉴">

--- a/graduate-business.html
+++ b/graduate-business.html
@@ -15,19 +15,49 @@
     <main>
         <section class="department-hero">
             <div class="container">
-                <span class="department-hero__label" aria-label="대학원 과정">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
-                    Graduate Program
-                </span>
-                <h1>경영대학원</h1>
-                <p>
-                    경영대학원은 글로벌 시장에서 경쟁력 있는 전략가와 혁신 리더를 양성합니다.
-                    MBA, 경영학 석·박사 과정을 통해 데이터 기반 의사결정과 ESG 경영, 스타트업 생태계를 심층 탐구합니다.
-                </p>
-                <div class="department-meta">
-                    <span>학위과정: MBA · 경영학 석·박사</span>
-                    <span>소속: 대학원</span>
-                    <span>표준수업연한: 2~4년</span>
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="대학원 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Graduate Program
+                        </span>
+                        <h1>경영대학원</h1>
+                        <p>
+                            경영대학원은 글로벌 시장에서 경쟁력 있는 전략가와 혁신 리더를 양성합니다.
+                            MBA, 경영학 석·박사 과정을 통해 데이터 기반 의사결정과 ESG 경영, 스타트업 생태계를 심층 탐구합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>학위과정: MBA · 경영학 석·박사</span>
+                            <span>소속: 대학원</span>
+                            <span>표준수업연한: 2~4년</span>
+                        </div>
+                    </div>
+                    <aside class="department-hero__faculty" aria-label="대표 교수진">
+                        <h2>대표 교수진</h2>
+                        <p class="department-hero__faculty-intro">글로벌 비즈니스와 데이터 분석 전문가들이 혁신 전략과 MBA 프로젝트를 지도합니다.</p>
+                        <div class="department-hero__faculty-list">
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWFmMGZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMzYTZmZjciLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMWYyYTQ0IiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMzYTZmZjciIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="윤세진 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">윤세진 교수</p>
+                                    <p class="faculty-card__role">MBA 경영전략</p>
+                                    <p class="faculty-card__focus">글로벌 비즈니스 모델 혁신과 스타트업 스케일업 전략을 연구합니다.</p>
+                                </div>
+                            </article>
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="Elena Park 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">Elena Park 교수</p>
+                                    <p class="faculty-card__role">데이터 애널리틱스</p>
+                                    <p class="faculty-card__focus">AI 기반 경영 의사결정과 ESG 데이터 분석 프로젝트를 이끕니다.</p>
+                                </div>
+                            </article>
+                        </div>
+                    </aside>
                 </div>
             </div>
             <nav class="department-tabs" aria-label="경영대학원 메뉴">

--- a/graduate-education.html
+++ b/graduate-education.html
@@ -15,19 +15,49 @@
     <main>
         <section class="department-hero">
             <div class="container">
-                <span class="department-hero__label" aria-label="대학원 과정">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
-                    Graduate Program
-                </span>
-                <h1>교육대학원</h1>
-                <p>
-                    교육대학원은 학교와 평생교육 현장에서 필요한 전문 역량을 강화하여 미래형 교육 리더를 양성합니다.
-                    교육 연구와 수업 혁신, 교육행정 역량을 통합적으로 개발합니다.
-                </p>
-                <div class="department-meta">
-                    <span>학위과정: 석사(M.Ed) · 교육학 박사(Ed.D.)</span>
-                    <span>소속: 대학원</span>
-                    <span>표준수업연한: 2~4년</span>
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="대학원 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Graduate Program
+                        </span>
+                        <h1>교육대학원</h1>
+                        <p>
+                            교육대학원은 학교와 평생교육 현장에서 필요한 전문 역량을 강화하여 미래형 교육 리더를 양성합니다.
+                            교육 연구와 수업 혁신, 교육행정 역량을 통합적으로 개발합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>학위과정: 석사(M.Ed) · 교육학 박사(Ed.D.)</span>
+                            <span>소속: 대학원</span>
+                            <span>표준수업연한: 2~4년</span>
+                        </div>
+                    </div>
+                    <aside class="department-hero__faculty" aria-label="대표 교수진">
+                        <h2>대표 교수진</h2>
+                        <p class="department-hero__faculty-intro">에듀테크와 교육리더십 전문가들이 미래형 수업 설계와 조직 혁신 연구를 이끕니다.</p>
+                        <div class="department-hero__faculty-list">
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWFmMGZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMzYTZmZjciLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMWYyYTQ0IiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMzYTZmZjciIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="김소연 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">김소연 교수</p>
+                                    <p class="faculty-card__role">미래교육</p>
+                                    <p class="faculty-card__focus">에듀테크 기반 수업 설계와 학습 분석을 활용한 맞춤형 교육 모델을 연구합니다.</p>
+                                </div>
+                            </article>
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="박지환 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">박지환 교수</p>
+                                    <p class="faculty-card__role">교육리더십</p>
+                                    <p class="faculty-card__focus">학교 조직 혁신과 코칭 리더십 프로그램을 통해 현장 중심의 변화를 지원합니다.</p>
+                                </div>
+                            </article>
+                        </div>
+                    </aside>
                 </div>
             </div>
             <nav class="department-tabs" aria-label="교육대학원 메뉴">

--- a/graduate-theology.html
+++ b/graduate-theology.html
@@ -15,19 +15,49 @@
     <main>
         <section class="department-hero">
             <div class="container">
-                <span class="department-hero__label" aria-label="대학원 과정">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
-                    Graduate Program
-                </span>
-                <h1>신학대학원</h1>
-                <p>
-                    신학대학원은 신학적 탐구와 목회 실천의 심화를 통해 교회와 사회를 섬길 수 있는 전문 사역자와 학자를 양성합니다.
-                    연구 중심 커리큘럼과 사역 현장을 연결하여 학문과 실천을 통합합니다.
-                </p>
-                <div class="department-meta">
-                    <span>학위과정: 석사(MDiv/MTS) · 박사(Th.D.)</span>
-                    <span>소속: 대학원</span>
-                    <span>표준수업연한: 2~4년</span>
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="대학원 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Graduate Program
+                        </span>
+                        <h1>신학대학원</h1>
+                        <p>
+                            신학대학원은 신학적 탐구와 목회 실천의 심화를 통해 교회와 사회를 섬길 수 있는 전문 사역자와 학자를 양성합니다.
+                            연구 중심 커리큘럼과 사역 현장을 연결하여 학문과 실천을 통합합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>학위과정: 석사(MDiv/MTS) · 박사(Th.D.)</span>
+                            <span>소속: 대학원</span>
+                            <span>표준수업연한: 2~4년</span>
+                        </div>
+                    </div>
+                    <aside class="department-hero__faculty" aria-label="대표 교수진">
+                        <h2>대표 교수진</h2>
+                        <p class="department-hero__faculty-intro">조직신학과 실천신학 분야의 석학들이 신학 연구와 목회 현장을 연결하는 심화 지도를 제공합니다.</p>
+                        <div class="department-hero__faculty-list">
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWFmMGZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMzYTZmZjciLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMWYyYTQ0IiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMzYTZmZjciIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="정하늘 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">정하늘 교수</p>
+                                    <p class="faculty-card__role">조직신학</p>
+                                    <p class="faculty-card__focus">다학제 신학 담론과 목회 적용을 연결하는 연구를 이끌고 있습니다.</p>
+                                </div>
+                            </article>
+                            <article class="faculty-card">
+                                <figure class="faculty-card__photo">
+                                    <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="Samuel Lee 교수의 프로필 사진" loading="lazy" />
+                                </figure>
+                                <div class="faculty-card__body">
+                                    <p class="faculty-card__name">Samuel Lee 교수</p>
+                                    <p class="faculty-card__role">실천신학</p>
+                                    <p class="faculty-card__focus">온라인 목회와 커뮤니티 케어 모델을 개발하며 글로벌 사역 네트워크를 운영합니다.</p>
+                                </div>
+                            </article>
+                        </div>
+                    </aside>
                 </div>
             </div>
             <nav class="department-tabs" aria-label="신학대학원 메뉴">


### PR DESCRIPTION
## Summary
- refactor the department hero layout to support a faculty spotlight column with responsive styling
- populate each college and graduate program hero with department-specific faculty cards using accessible inline profile images

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e5cf3053cc8332a84d307af236aa2c