### PR TITLE
Reduce spacing between department tabs and panels

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1184,6 +1184,10 @@ body.theme-dark .dark-mode-toggle {
     padding: 3.5rem 0;
 }
 
+.department-tabs + .department-section {
+    padding-top: 0;
+}
+
 .department-section:nth-of-type(even) {
     background: var(--bg);
 }


### PR DESCRIPTION
## Summary
- remove the extra top padding above the first department tab panel so the content sits flush with the tabs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5dd0e771083329c22aef9084d5ca0