### PR TITLE
Move department tabs into department hero containers

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1035,13 +1035,17 @@ body.theme-dark .dark-mode-toggle {
     font-size: 0.95rem;
 }
 
+.department-hero .department-tabs {
+    margin-top: 2.5rem;
+}
+
 .department-tabs {
     border-top: 1px solid rgba(31, 42, 68, 0.08);
     border-bottom: 1px solid rgba(31, 42, 68, 0.08);
     background: var(--white);
 }
 
-.department-tabs .container {
+.department-tabs__list {
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem;
@@ -1184,7 +1188,7 @@ body.theme-dark .dark-mode-toggle {
     padding: 3.5rem 0;
 }
 
-.department-tabs + .department-section {
+.department-hero + .department-section {
     padding-top: 0;
 }
 

--- a/college-business.html
+++ b/college-business.html
@@ -33,16 +33,16 @@
                         </div>
                     </div>
                 </div>
+                <nav class="department-tabs" aria-label="경영학과 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
+                    </div>
+                </nav>
             </div>
-            <nav class="department-tabs" aria-label="경영학과 메뉴">
-                <div class="container" role="tablist">
-                    <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
-                    <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
-                    <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
-                    <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
-                    <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
-                </div>
-            </nav>
         </section>
 
         <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">

--- a/college-christian-education.html
+++ b/college-christian-education.html
@@ -33,16 +33,16 @@
                         </div>
                     </div>
                 </div>
+                <nav class="department-tabs" aria-label="기독교교육학과 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
+                    </div>
+                </nav>
             </div>
-            <nav class="department-tabs" aria-label="기독교교육학과 메뉴">
-                <div class="container" role="tablist">
-                    <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
-                    <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
-                    <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
-                    <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
-                    <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
-                </div>
-            </nav>
         </section>
 
         <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">

--- a/college-counseling.html
+++ b/college-counseling.html
@@ -33,16 +33,16 @@
                         </div>
                     </div>
                 </div>
+                <nav class="department-tabs" aria-label="상담학과 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
+                    </div>
+                </nav>
             </div>
-            <nav class="department-tabs" aria-label="상담학과 메뉴">
-                <div class="container" role="tablist">
-                    <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
-                    <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
-                    <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
-                    <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
-                    <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
-                </div>
-            </nav>
         </section>
 
         <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">

--- a/college-customs.html
+++ b/college-customs.html
@@ -33,16 +33,16 @@
                         </div>
                     </div>
                 </div>
+                <nav class="department-tabs" aria-label="관세학과 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
+                    </div>
+                </nav>
             </div>
-            <nav class="department-tabs" aria-label="관세학과 메뉴">
-                <div class="container" role="tablist">
-                    <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
-                    <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
-                    <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
-                    <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
-                    <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
-                </div>
-            </nav>
         </section>
 
         <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">

--- a/college-english.html
+++ b/college-english.html
@@ -33,16 +33,16 @@
                         </div>
                     </div>
                 </div>
+                <nav class="department-tabs" aria-label="영어학과 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
+                    </div>
+                </nav>
             </div>
-            <nav class="department-tabs" aria-label="영어학과 메뉴">
-                <div class="container" role="tablist">
-                    <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
-                    <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
-                    <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
-                    <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
-                    <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
-                </div>
-            </nav>
         </section>
 
         <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">

--- a/college-music-education.html
+++ b/college-music-education.html
@@ -33,16 +33,16 @@
                         </div>
                     </div>
                 </div>
+                <nav class="department-tabs" aria-label="음악교육학과 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
+                    </div>
+                </nav>
             </div>
-            <nav class="department-tabs" aria-label="음악교육학과 메뉴">
-                <div class="container" role="tablist">
-                    <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
-                    <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
-                    <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
-                    <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
-                    <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
-                </div>
-            </nav>
         </section>
 
         <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">

--- a/college-physical-education.html
+++ b/college-physical-education.html
@@ -33,16 +33,16 @@
                         </div>
                     </div>
                 </div>
+                <nav class="department-tabs" aria-label="체육교육학과 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
+                    </div>
+                </nav>
             </div>
-            <nav class="department-tabs" aria-label="체육교육학과 메뉴">
-                <div class="container" role="tablist">
-                    <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
-                    <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
-                    <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
-                    <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
-                    <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
-                </div>
-            </nav>
         </section>
 
         <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">

--- a/college-public-administration.html
+++ b/college-public-administration.html
@@ -33,16 +33,16 @@
                         </div>
                     </div>
                 </div>
+                <nav class="department-tabs" aria-label="행정학과 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
+                    </div>
+                </nav>
             </div>
-            <nav class="department-tabs" aria-label="행정학과 메뉴">
-                <div class="container" role="tablist">
-                    <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
-                    <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
-                    <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
-                    <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
-                    <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
-                </div>
-            </nav>
         </section>
 
         <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">

--- a/college-real-estate.html
+++ b/college-real-estate.html
@@ -33,16 +33,16 @@
                         </div>
                     </div>
                 </div>
+                <nav class="department-tabs" aria-label="부동산학과 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
+                    </div>
+                </nav>
             </div>
-            <nav class="department-tabs" aria-label="부동산학과 메뉴">
-                <div class="container" role="tablist">
-                    <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
-                    <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
-                    <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
-                    <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
-                    <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
-                </div>
-            </nav>
         </section>
 
         <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">

--- a/college-social-welfare.html
+++ b/college-social-welfare.html
@@ -33,16 +33,16 @@
                         </div>
                     </div>
                 </div>
+                <nav class="department-tabs" aria-label="복지학과 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
+                    </div>
+                </nav>
             </div>
-            <nav class="department-tabs" aria-label="복지학과 메뉴">
-                <div class="container" role="tablist">
-                    <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
-                    <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
-                    <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
-                    <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
-                    <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
-                </div>
-            </nav>
         </section>
 
         <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">

--- a/college-theology.html
+++ b/college-theology.html
@@ -33,16 +33,16 @@
                         </div>
                     </div>
                 </div>
+                <nav class="department-tabs" aria-label="신학과 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
+                    </div>
+                </nav>
             </div>
-            <nav class="department-tabs" aria-label="신학과 메뉴">
-                <div class="container" role="tablist">
-                    <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
-                    <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
-                    <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
-                    <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
-                    <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
-                </div>
-            </nav>
         </section>
 
         <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">

--- a/graduate-business.html
+++ b/graduate-business.html
@@ -33,16 +33,16 @@
                         </div>
                     </div>
                 </div>
+                <nav class="department-tabs" aria-label="경영대학원 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
+                    </div>
+                </nav>
             </div>
-            <nav class="department-tabs" aria-label="경영대학원 메뉴">
-                <div class="container" role="tablist">
-                    <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
-                    <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
-                    <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
-                    <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
-                    <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
-                </div>
-            </nav>
         </section>
 
         <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">

--- a/graduate-education.html
+++ b/graduate-education.html
@@ -33,16 +33,16 @@
                         </div>
                     </div>
                 </div>
+                <nav class="department-tabs" aria-label="교육대학원 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
+                    </div>
+                </nav>
             </div>
-            <nav class="department-tabs" aria-label="교육대학원 메뉴">
-                <div class="container" role="tablist">
-                    <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
-                    <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
-                    <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
-                    <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
-                    <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
-                </div>
-            </nav>
         </section>
 
         <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">

--- a/graduate-theology.html
+++ b/graduate-theology.html
@@ -33,16 +33,16 @@
                         </div>
                     </div>
                 </div>
+                <nav class="department-tabs" aria-label="신학대학원 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
+                    </div>
+                </nav>
             </div>
-            <nav class="department-tabs" aria-label="신학대학원 메뉴">
-                <div class="container" role="tablist">
-                    <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">학과소개</a>
-                    <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">교과과정</a>
-                    <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
-                    <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학생지원</a>
-                    <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">대표 교수진</a>
-                </div>
-            </nav>
         </section>
 
         <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">


### PR DESCRIPTION
## Summary
- nest each department page's tab navigation inside the department hero container so the menu sits at the bottom of the hero area
- adjust shared styles to support the new markup and preserve the spacing before the first department section

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5df6083c4833286a2569b0893b1c3