### PR TITLE
Show faculty preview when faculty tab is selected

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1086,6 +1086,15 @@ body.theme-dark .dark-mode-toggle {
     gap: 1.5rem;
 }
 
+.department-hero__faculty--preview {
+    align-self: stretch;
+    max-width: 28rem;
+}
+
+.department-hero__faculty--preview[hidden] {
+    display: none;
+}
+
 .department-hero__faculty h2 {
     font-size: 1.35rem;
     margin: 0;
@@ -1169,6 +1178,10 @@ body.theme-dark .dark-mode-toggle {
 
     .department-hero__faculty {
         padding: 1.5rem;
+    }
+
+    .department-hero__faculty--preview {
+        max-width: none;
     }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -535,6 +535,7 @@ const initialize = () => {
             }
 
             const heroLayout = tabGroup.closest('.department-hero')?.querySelector('.department-hero__layout') || null;
+            let heroFacultyPreview = heroLayout?.querySelector('[data-hero-faculty-preview]') || null;
 
             const getPanel = (tab) => {
                 const controls = tab.getAttribute('aria-controls');
@@ -545,13 +546,45 @@ const initialize = () => {
                 return document.getElementById(controls);
             };
 
+            const facultyTab = tabs.find((tab) => tab.getAttribute('aria-controls') === 'faculty') || null;
+            const facultyPanel = facultyTab ? getPanel(facultyTab) : null;
+
+            if (!heroFacultyPreview && heroLayout && facultyPanel) {
+                const previewSource = facultyPanel.querySelector('.department-hero__faculty');
+                if (previewSource) {
+                    heroFacultyPreview = previewSource.cloneNode(true);
+                    heroFacultyPreview.setAttribute('data-hero-faculty-preview', '');
+                    heroFacultyPreview.setAttribute('aria-hidden', 'true');
+                    heroFacultyPreview.setAttribute('hidden', '');
+                    heroFacultyPreview.classList.add('department-hero__faculty--preview');
+
+                    const previewCards = heroFacultyPreview.querySelectorAll('.faculty-card');
+                    previewCards.forEach((card, index) => {
+                        if (index > 1) {
+                            card.remove();
+                        }
+                    });
+
+                    heroLayout.appendChild(heroFacultyPreview);
+                }
+            }
+
             const updateHeroLayout = (activeTab) => {
                 if (!heroLayout) {
                     return;
                 }
 
                 const controls = activeTab?.getAttribute('aria-controls');
-                heroLayout.classList.toggle('has-faculty', controls === 'faculty');
+                const shouldShowFaculty = controls === 'faculty' && heroFacultyPreview;
+                heroLayout.classList.toggle('has-faculty', Boolean(shouldShowFaculty));
+
+                if (heroFacultyPreview) {
+                    if (shouldShowFaculty) {
+                        heroFacultyPreview.removeAttribute('hidden');
+                    } else {
+                        heroFacultyPreview.setAttribute('hidden', '');
+                    }
+                }
             };
 
             const setActive = (targetTab, options = {}) => {


### PR DESCRIPTION
## Summary
- clone the faculty panel content into the department hero layout so the faculty tab mirrors other tab behavior
- add styles for the hero faculty preview including responsive adjustments

## Testing
- Manual verification via Playwright screenshot of the faculty tab

------
https://chatgpt.com/codex/tasks/task_e_68e5e3751594833293f476bb808e2563