### PR TITLE
Align faculty preview with hero summary styling

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -557,6 +557,7 @@ const initialize = () => {
                     heroFacultyPreview.setAttribute('aria-hidden', 'true');
                     heroFacultyPreview.setAttribute('hidden', '');
                     heroFacultyPreview.classList.add('department-hero__faculty--preview');
+                    heroFacultyPreview.classList.add('department-hero__summary');
 
                     const previewCards = heroFacultyPreview.querySelectorAll('.faculty-card');
                     previewCards.forEach((card, index) => {


### PR DESCRIPTION
## Summary
- ensure the department hero faculty preview uses the same summary styling when the faculty tab is activated

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5e733365883329f4fd152feeb1d88