### PR TITLE
Remove faculty preview feature

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -977,10 +977,6 @@ body.theme-dark .dark-mode-toggle {
     align-items: start;
 }
 
-.department-hero__layout.has-faculty {
-    grid-template-columns: minmax(0, 1.75fr) minmax(0, 1fr);
-}
-
 .department-hero__summary {
     display: flex;
     flex-direction: column;
@@ -1086,15 +1082,6 @@ body.theme-dark .dark-mode-toggle {
     gap: 1.5rem;
 }
 
-.department-hero__faculty--preview {
-    align-self: stretch;
-    max-width: 28rem;
-}
-
-.department-hero__faculty--preview[hidden] {
-    display: none;
-}
-
 .department-hero__faculty h2 {
     font-size: 1.35rem;
     margin: 0;
@@ -1171,17 +1158,12 @@ body.theme-dark .dark-mode-toggle {
 }
 
 @media (max-width: 960px) {
-    .department-hero__layout,
-    .department-hero__layout.has-faculty {
+    .department-hero__layout {
         grid-template-columns: 1fr;
     }
 
     .department-hero__faculty {
         padding: 1.5rem;
-    }
-
-    .department-hero__faculty--preview {
-        max-width: none;
     }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -534,9 +534,6 @@ const initialize = () => {
                 return;
             }
 
-            const heroLayout = tabGroup.closest('.department-hero')?.querySelector('.department-hero__layout') || null;
-            let heroFacultyPreview = heroLayout?.querySelector('[data-hero-faculty-preview]') || null;
-
             const getPanel = (tab) => {
                 const controls = tab.getAttribute('aria-controls');
                 if (!controls) {
@@ -544,48 +541,6 @@ const initialize = () => {
                 }
 
                 return document.getElementById(controls);
-            };
-
-            const facultyTab = tabs.find((tab) => tab.getAttribute('aria-controls') === 'faculty') || null;
-            const facultyPanel = facultyTab ? getPanel(facultyTab) : null;
-
-            if (!heroFacultyPreview && heroLayout && facultyPanel) {
-                const previewSource = facultyPanel.querySelector('.department-hero__faculty');
-                if (previewSource) {
-                    heroFacultyPreview = previewSource.cloneNode(true);
-                    heroFacultyPreview.setAttribute('data-hero-faculty-preview', '');
-                    heroFacultyPreview.setAttribute('aria-hidden', 'true');
-                    heroFacultyPreview.setAttribute('hidden', '');
-                    heroFacultyPreview.classList.add('department-hero__faculty--preview');
-                    heroFacultyPreview.classList.add('department-hero__summary');
-
-                    const previewCards = heroFacultyPreview.querySelectorAll('.faculty-card');
-                    previewCards.forEach((card, index) => {
-                        if (index > 1) {
-                            card.remove();
-                        }
-                    });
-
-                    heroLayout.appendChild(heroFacultyPreview);
-                }
-            }
-
-            const updateHeroLayout = (activeTab) => {
-                if (!heroLayout) {
-                    return;
-                }
-
-                const controls = activeTab?.getAttribute('aria-controls');
-                const shouldShowFaculty = controls === 'faculty' && heroFacultyPreview;
-                heroLayout.classList.toggle('has-faculty', Boolean(shouldShowFaculty));
-
-                if (heroFacultyPreview) {
-                    if (shouldShowFaculty) {
-                        heroFacultyPreview.removeAttribute('hidden');
-                    } else {
-                        heroFacultyPreview.setAttribute('hidden', '');
-                    }
-                }
             };
 
             const setActive = (targetTab, options = {}) => {
@@ -615,8 +570,6 @@ const initialize = () => {
                         panel.setAttribute('hidden', '');
                     }
                 });
-
-                updateHeroLayout(targetTab);
 
                 if (updateHash && activeControls) {
                     const newHash = `#${activeControls}`;


### PR DESCRIPTION
## Summary
- remove the hero faculty preview cloning logic from the department tabs script
- clean up department hero layout styles that were only used by the preview block

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5e8f53edc8332803e84efc2ff0e4f