### PR TITLE
Add lifelong education program pages and update navigation

### DIFF
--- a/assets/partials/header.html
+++ b/assets/partials/header.html
@@ -182,44 +182,49 @@
                                 <section class="mega-section">
                                     <h3>교양교육과정</h3>
                                     <ul>
-                                        <li><a href="convergence.html#curriculum">교양아카데미</a></li>
-                                        <li><a href="convergence.html#curriculum">국가및민간자격</a></li>
-                                        <li><a href="convergence.html#curriculum">국제민간자격</a></li>
+                                        <li><a href="lifelong-liberal-arts.html">과정 소개</a></li>
+                                        <li><a href="lifelong-liberal-arts.html#curriculum">모듈 구성</a></li>
+                                        <li><a href="lifelong-liberal-arts.html#support">지원 서비스</a></li>
                                     </ul>
                                 </section>
                                 <section class="mega-section">
-                                    <a class="mega-heading" href="convergence.html#curriculum">커리큘럼 한눈에 보기</a>
-                                </section>
-                            </div>
-                            <div class="mega-column">
-                                <section class="mega-section">
-                                    <h3>전문,자격과정</h3>
+                                    <h3>전문과정</h3>
                                     <ul>
-                                        <li><a href="convergence.html#business">테솔과정</a></li>
-                                        <li><a href="convergence.html#business">영어마스터과정</a></li>
-                                        <li><a href="convergence.html#business">기타전문자격과정</a></li>
-                                    </ul>
-                                </section>
-                                <section class="mega-section">
-                                    <h3>위탁 과정</h3>
-                                    <ul>
-                                        <li><a href="convergence.html#tech">실습지원센터</a></li>
-                                        <li><a href="convergence.html#tech">편입학위과정</a></li>
-                                        <li><a href="convergence.html#tech">학습지원센터</a></li>
+                                        <li><a href="lifelong-professional.html">과정 특징</a></li>
+                                        <li><a href="lifelong-professional.html#curriculum">트랙 구성</a></li>
+                                        <li><a href="lifelong-professional.html#career">산업 연계</a></li>
                                     </ul>
                                 </section>
                             </div>
                             <div class="mega-column">
                                 <section class="mega-section">
-                                    <h3>협약사업</h3>
+                                    <h3>자격과정</h3>
                                     <ul>
-                                        <li><a href="convergence.html#creative">사업부분</a></li>
-                                        <li><a href="convergence.html#creative">교육부분</a></li>
-                                        <li><a href="convergence.html#creative">인턴부분</a></li>
+                                        <li><a href="lifelong-certification.html">프로그램 소개</a></li>
+                                        <li><a href="lifelong-certification.html#curriculum">과정 구성</a></li>
+                                        <li><a href="lifelong-certification.html#support">학습 지원</a></li>
                                     </ul>
                                 </section>
                                 <section class="mega-section">
-                                    <a class="mega-heading" href="support.html">학습 지원 센터</a>
+                                    <h3>위탁과정</h3>
+                                    <ul>
+                                        <li><a href="lifelong-commissioned.html">사업 소개</a></li>
+                                        <li><a href="lifelong-commissioned.html#curriculum">운영 모델</a></li>
+                                        <li><a href="lifelong-commissioned.html#support">지원 체계</a></li>
+                                    </ul>
+                                </section>
+                            </div>
+                            <div class="mega-column">
+                                <section class="mega-section">
+                                    <a class="mega-heading" href="convergence.html">평생교육원 메인으로</a>
+                                </section>
+                                <section class="mega-section">
+                                    <h3>빠른 연결</h3>
+                                    <ul>
+                                        <li><a href="support.html">학습 지원 센터</a></li>
+                                        <li><a href="admissions.html">상담 예약</a></li>
+                                        <li><a href="programs.html#departments">전체 전공 보기</a></li>
+                                    </ul>
                                 </section>
                             </div>
                         </div>

--- a/lifelong-certification.html
+++ b/lifelong-certification.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>자격과정 | GTCC 평생교육원</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="평생교육원 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Lifelong Education Program
+                        </span>
+                        <h1>자격과정</h1>
+                        <p>
+                            자격과정은 국내외 공인 자격증 취득을 목표로 체계적인 학습 로드맵과 실습을 제공하는 프로그램입니다.
+                            TESOL, 국제민간자격, 전문상담사 등 다양한 분야의 자격 준비를 지원하며, 최신 출제 경향을 반영한 맞춤형 커리큘럼을 운영합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>과정 구분: 자격 취득</span>
+                            <span>운영 형태: 온라인 강의 + 오프라인 특강</span>
+                            <span>이수 기간: 2개월 ~ 1년</span>
+                        </div>
+                    </div>
+                </div>
+                <nav class="department-tabs" aria-label="자격과정 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">프로그램 소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">과정 구성</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">자격 활용</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학습 지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">전문 강사진</a>
+                    </div>
+                </nav>
+            </div>
+        </section>
+
+        <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>프로그램 소개</h2>
+                    <p>
+                        자격과정은 모의 시험, 실습 워크숍, 스터디 코칭 등 단계별 학습 전략을 제공하여 합격 가능성을 높입니다.
+                        GTCC 시험정보센터와 연계하여 시험 일정, 원서 접수, 응시 전략 등 실질적인 정보를 제공합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">상담 및 접수</a>
+                        <a class="btn ghost" href="support.html#services">자격증 정보센터</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">맞춤 학습 설계</h3>
+                            <p class="department-list__subtitle">Personalized Certification Plan</p>
+                            <p class="department-list__body">학습 수준 진단을 기반으로 과목별 학습 플랜과 모의고사 일정을 제공합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">실전 대비 워크숍</h3>
+                            <p class="department-list__subtitle">Practical Exam Workshop</p>
+                            <p class="department-list__body">현장 시나리오 기반 실습과 피드백을 통해 실전 감각을 강화합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">국제 네트워크</h3>
+                            <p class="department-list__subtitle">Global Certification Network</p>
+                            <p class="department-list__body">해외 기관과 협력하여 국제 자격 인증 절차와 취업 정보를 제공합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section" role="tabpanel" aria-labelledby="tab-curriculum" tabindex="0">
+            <div class="container department-layout">
+                <div>
+                    <h2>과정 구성</h2>
+                    <p>
+                        자격과정은 자격 분야별 핵심 이론, 문제 해결 전략, 실습 모듈로 구성되어 있으며, 단계별 모의 평가를 통해 학습 성취를 점검합니다.
+                        과정별 전용 온라인 학습실과 오프라인 집중 캠프를 제공하여 학습 효과를 극대화합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>TESOL & 어학 자격</h3>
+                        <ul>
+                            <li>어학 교수법 이론</li>
+                            <li>마이크로 티칭 실습</li>
+                            <li>국제 인증 시험 대비반</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>상담 · 복지 자격</h3>
+                        <ul>
+                            <li>상담 심리 이론 & 사례</li>
+                            <li>슈퍼비전 그룹 코칭</li>
+                            <li>실무 포트폴리오 작성</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>전문 실무 자격</h3>
+                        <ul>
+                            <li>자격 출제 경향 분석</li>
+                            <li>실기 시험 실습 장비 제공</li>
+                            <li>시험 직전 집중 특강</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section" role="tabpanel" aria-labelledby="tab-career" tabindex="0">
+            <div class="container department-layout">
+                <h2>자격 활용 분야</h2>
+                <p>
+                    자격 취득 후 교육 기관, 상담 센터, 국제기구, 기업 교육팀 등 다양한 현장에서 전문성을 발휘할 수 있습니다.
+                    GTCC 평생교육원은 취업 연계 컨설팅과 해외 기관 추천서를 제공하여 글로벌 진출을 지원합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>교육 · 어학</strong>
+                        <p>어학원 강사, 기업 교육 강사, 온라인 콘텐츠 제작자</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>상담 · 복지</strong>
+                        <p>청소년 상담사, 노인복지 상담 전문가, 사회복지기관 실무자</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>국제 자격</strong>
+                        <p>국제 교육 기관, 해외 NGO, 글로벌 기업 전문직</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section" role="tabpanel" aria-labelledby="tab-support" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학습 지원</h2>
+                    <p>
+                        자격 대비 학습자는 전담 코치와 주간 학습 점검, 모의고사 성적 분석, 학습법 세미나를 제공받습니다.
+                        또한 시험 직전 집중 관리반을 운영하여 응시 전략과 컨디션 관리까지 세밀하게 지원합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>스터디 코칭</h3>
+                        <ul>
+                            <li>자격별 학습 캘린더 제공</li>
+                            <li>주간 모의고사 & 리뷰 세션</li>
+                            <li>1:1 질의 응답 채널 운영</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>시험 지원</h3>
+                        <ul>
+                            <li>원서 접수 및 응시 일정 안내</li>
+                            <li>시험장 안내 및 실습 장비 지원</li>
+                            <li>합격 후 자격 등록 컨설팅</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="faculty" class="department-section" role="tabpanel" aria-labelledby="tab-faculty" tabindex="0">
+            <div class="container">
+                <div class="department-hero__faculty">
+                    <h2>전문 강사진</h2>
+                    <p class="department-hero__faculty-intro">시험 합격 전략과 실무 경험을 겸비한 강사진이 단계별 학습을 책임집니다.</p>
+                    <div class="department-hero__faculty-list">
+                        <article class="faculty-card">
+                            <figure class="faculty-card__photo">
+                                <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWFmMGZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMzYTZmZjciLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMWYyYTQ0IiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMzYTZmZjciIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="홍세린 강사의 프로필 사진" loading="lazy" />
+                            </figure>
+                            <div class="faculty-card__body">
+                                <p class="faculty-card__name">홍세린 강사</p>
+                                <p class="faculty-card__role">TESOL 마스터 트레이너</p>
+                                <p class="faculty-card__focus">국제 어학 자격 시험 분석과 수업 설계 노하우를 제공하며 실전 감각을 높입니다.</p>
+                            </div>
+                        </article>
+                        <article class="faculty-card">
+                            <figure class="faculty-card__photo">
+                                <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="백준혁 강사의 프로필 사진" loading="lazy" />
+                            </figure>
+                            <div class="faculty-card__body">
+                                <p class="faculty-card__name">백준혁 강사</p>
+                                <p class="faculty-card__role">상담 심리 전문가</p>
+                                <p class="faculty-card__focus">상담 실무 사례 분석과 슈퍼비전을 통해 자격 취득 후 현장 적응을 돕습니다.</p>
+                            </div>
+                        </article>
+                        <article class="faculty-card">
+                            <figure class="faculty-card__photo">
+                                <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWRmN2ZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiM1YmY1ZmQiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMmRhOGZkIiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiM1YmY1ZmQiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="이한별 강사의 프로필 사진" loading="lazy" />
+                            </figure>
+                            <div class="faculty-card__body">
+                                <p class="faculty-card__name">이한별 강사</p>
+                                <p class="faculty-card__role">국제 자격 컨설턴트</p>
+                                <p class="faculty-card__focus">해외 자격 인증 절차와 커리어 패스를 설계하여 글로벌 진출을 지원합니다.</p>
+                            </div>
+                        </article>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/lifelong-commissioned.html
+++ b/lifelong-commissioned.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>위탁과정 | GTCC 평생교육원</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="평생교육원 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Lifelong Education Program
+                        </span>
+                        <h1>위탁과정</h1>
+                        <p>
+                            위탁과정은 공공기관, 기업, 지역사회 단체와 협력하여 현장 수요에 맞춘 맞춤형 교육을 제공하는 프로그램입니다.
+                            조직 역량 강화, 직무 재교육, 지역 맞춤형 프로젝트 등 다양한 형태로 운영되며, 온·오프라인 혼합 학습으로 효율성을 극대화합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>과정 구분: 기관 위탁 교육</span>
+                            <span>운영 형태: 맞춤형 프로젝트</span>
+                            <span>이수 기간: 계약에 따라 4주 ~ 1년</span>
+                        </div>
+                    </div>
+                </div>
+                <nav class="department-tabs" aria-label="위탁과정 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">사업 소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">운영 모델</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">성과 사례</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">지원 체계</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">전담 운영진</a>
+                    </div>
+                </nav>
+            </div>
+        </section>
+
+        <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>사업 소개</h2>
+                    <p>
+                        위탁과정은 기관의 교육 목표와 대상에 맞춰 사전 진단, 교육 설계, 실행, 평가까지 전 과정을 통합 지원합니다.
+                        GTCC 컨설턴트가 참여하여 맞춤형 커리큘럼을 설계하고, 학습 성과 분석 리포트를 제공해 조직 혁신을 돕습니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="support.html#career">위탁 문의</a>
+                        <a class="btn ghost" href="industry-collaboration.html">산학협력 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">사전 진단</h3>
+                            <p class="department-list__subtitle">Needs Analysis</p>
+                            <p class="department-list__body">조직의 역량과 교육 수요를 진단해 맞춤형 교육 목표를 설정합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">맞춤 설계</h3>
+                            <p class="department-list__subtitle">Customized Program Design</p>
+                            <p class="department-list__body">학습자 특성에 맞춘 모듈형 커리큘럼과 평가 지표를 설계합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">성과 분석</h3>
+                            <p class="department-list__subtitle">Impact Evaluation</p>
+                            <p class="department-list__body">교육 이후 성과 데이터를 분석하여 조직 변화와 ROI를 시각화합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section" role="tabpanel" aria-labelledby="tab-curriculum" tabindex="0">
+            <div class="container department-layout">
+                <div>
+                    <h2>운영 모델</h2>
+                    <p>
+                        위탁과정은 기관 유형에 따라 공공 혁신형, 기업 맞춤형, 지역 상생형 세 가지 모델로 운영됩니다.
+                        각 모델은 온라인 학습 플랫폼, 실습 워크숍, 현장 컨설팅을 결합하여 실질적인 조직 변화를 이끌어냅니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>공공 혁신형</h3>
+                        <ul>
+                            <li>정책 이해 및 시민소통 교육</li>
+                            <li>공공 데이터 활용 프로젝트</li>
+                            <li>성과 공유 컨퍼런스</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>기업 맞춤형</h3>
+                        <ul>
+                            <li>직무 재설계 워크숍</li>
+                            <li>디지털 전환 실습</li>
+                            <li>성과 코칭 & 코칭 클리닉</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>지역 상생형</h3>
+                        <ul>
+                            <li>지역 문제 해결 디자인 씽킹</li>
+                            <li>현장 프로젝트 & 멘토링</li>
+                            <li>지역 성과 박람회 개최</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section" role="tabpanel" aria-labelledby="tab-career" tabindex="0">
+            <div class="container department-layout">
+                <h2>성과 사례</h2>
+                <p>
+                    GTCC 평생교육원은 연간 50개 이상의 기관과 협력하여 조직 맞춤형 교육을 제공하고 있으며, 교육 만족도와 재계약률에서 높은 평가를 받고 있습니다.
+                    교육 결과는 데이터 기반 리포트로 제공되어 향후 정책 및 사업 계획 수립에 활용됩니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>공공기관</strong>
+                        <p>디지털 행정 역량 강화 교육 후 민원 처리 속도 25% 향상</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>기업 파트너</strong>
+                        <p>신규 서비스 런칭 프로젝트에서 사내 혁신팀 역량 지표 30% 개선</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>지역 단체</strong>
+                        <p>지역 청년 창업캠프 운영으로 창업 준비팀 12개 육성</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section" role="tabpanel" aria-labelledby="tab-support" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>지원 체계</h2>
+                    <p>
+                        위탁기관에는 교육 운영 매니저, 콘텐츠 디자이너, 데이터 분석가로 구성된 전담팀이 배정됩니다.
+                        교육 운영 전 과정은 전용 플랫폼에서 모니터링되며, 주간 리포트와 성과 분석 회의를 통해 지속적인 개선을 지원합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>운영 지원</h3>
+                        <ul>
+                            <li>전담 매니저 상시 상담</li>
+                            <li>실시간 학습 참여 현황 분석</li>
+                            <li>교육 만족도 조사 & 피드백</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>성과 관리</h3>
+                        <ul>
+                            <li>데이터 기반 성과 리포트</li>
+                            <li>성과 공유 워크숍</li>
+                            <li>후속 실행 계획 컨설팅</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="faculty" class="department-section" role="tabpanel" aria-labelledby="tab-faculty" tabindex="0">
+            <div class="container">
+                <div class="department-hero__faculty">
+                    <h2>전담 운영진</h2>
+                    <p class="department-hero__faculty-intro">위탁 교육의 기획부터 실행까지 책임지는 전문가들이 조직별 맞춤 컨설팅을 제공합니다.</p>
+                    <div class="department-hero__faculty-list">
+                        <article class="faculty-card">
+                            <figure class="faculty-card__photo">
+                                <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWFmMGZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMzYTZmZjciLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMWYyYTQ0IiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMzYTZmZjciIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="서유진 운영총괄의 프로필 사진" loading="lazy" />
+                            </figure>
+                            <div class="faculty-card__body">
+                                <p class="faculty-card__name">서유진 운영총괄</p>
+                                <p class="faculty-card__role">프로그램 디렉터</p>
+                                <p class="faculty-card__focus">기관 맞춤 교육 전략 수립과 파트너십 관리를 총괄합니다.</p>
+                            </div>
+                        </article>
+                        <article class="faculty-card">
+                            <figure class="faculty-card__photo">
+                                <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="남도현 학습디자이너의 프로필 사진" loading="lazy" />
+                            </figure>
+                            <div class="faculty-card__body">
+                                <p class="faculty-card__name">남도현 학습디자이너</p>
+                                <p class="faculty-card__role">러닝 익스피리언스 디자이너</p>
+                                <p class="faculty-card__focus">모듈형 커리큘럼 개발과 학습 경험 설계를 담당합니다.</p>
+                            </div>
+                        </article>
+                        <article class="faculty-card">
+                            <figure class="faculty-card__photo">
+                                <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWRmN2ZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiM1YmY1ZmQiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMmRhOGZkIiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiM1YmY1ZmQiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="지하윤 데이터분석가의 프로필 사진" loading="lazy" />
+                            </figure>
+                            <div class="faculty-card__body">
+                                <p class="faculty-card__name">지하윤 데이터분석가</p>
+                                <p class="faculty-card__role">성과 분석 전문가</p>
+                                <p class="faculty-card__focus">교육 효과 측정과 데이터 기반 리포트 작성 업무를 담당합니다.</p>
+                            </div>
+                        </article>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/lifelong-liberal-arts.html
+++ b/lifelong-liberal-arts.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>교양교육과정 | GTCC 평생교육원</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="평생교육원 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Lifelong Education Program
+                        </span>
+                        <h1>교양교육과정</h1>
+                        <p>
+                            교양교육과정은 시민으로서 갖추어야 할 핵심 소양과 디지털 리터러시를 균형 있게 학습하도록 설계된 통합 교양 프로그램입니다.
+                            학습자 주도 프로젝트와 토론 기반 수업을 통해 스스로 문제를 정의하고 해결하는 능력을 길러 미래 사회에 필요한 융합형 인재로 성장할 수 있습니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>과정 구분: 교양 · 인문</span>
+                            <span>운영 형태: 비학위(학점 인정 가능)</span>
+                            <span>이수 기간: 6개월 ~ 1년</span>
+                        </div>
+                    </div>
+                </div>
+                <nav class="department-tabs" aria-label="교양교육과정 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">과정 소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">모듈 구성</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">학습 성과</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">지원 서비스</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">전담 교수진</a>
+                    </div>
+                </nav>
+            </div>
+        </section>
+
+        <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>과정 소개</h2>
+                    <p>
+                        교양교육과정은 인문학적 성찰, 데이터 기반 사고, 글로벌 시민성을 아우르는 균형 잡힌 교과로 구성되어 있습니다.
+                        온라인 실시간 세미나와 온·오프라인 커뮤니티 학습을 결합해 개인의 흥미와 진로에 맞춘 맞춤형 학습 설계를 지원합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">학습 설계 가이드</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">핵심 역량 트랙</h3>
+                            <p class="department-list__subtitle">Core Competency Studio</p>
+                            <p class="department-list__body">비판적 사고, 의사소통, 데이터 활용 능력 등 필수 역량을 집중 훈련합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">프로젝트 기반 학습</h3>
+                            <p class="department-list__subtitle">Project-Based Learning</p>
+                            <p class="department-list__body">생활 밀착형 주제를 선정해 팀 프로젝트를 수행하며 문제 해결 능력을 강화합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">커뮤니티 라운지</h3>
+                            <p class="department-list__subtitle">Community Learning Lab</p>
+                            <p class="department-list__body">전문 멘토와 함께하는 토론·독서 클럽으로 지속 가능한 학습 네트워크를 구축합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section" role="tabpanel" aria-labelledby="tab-curriculum" tabindex="0">
+            <div class="container department-layout">
+                <div>
+                    <h2>모듈 구성</h2>
+                    <p>
+                        인문 기반 교양, 디지털 리터러시, 사회 참여형 실천 모듈로 구성되어 단계적으로 역량을 확장합니다.
+                        모든 모듈은 온라인 강의, 실시간 워크숍, 현장 체험 학습이 결합된 하이브리드 방식으로 운영됩니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>기초 인문 모듈</h3>
+                        <ul>
+                            <li>철학과 윤리적 판단</li>
+                            <li>미디어 리터러시 워크숍</li>
+                            <li>글로벌 시민 리더십</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>융합 역량 모듈</h3>
+                        <ul>
+                            <li>데이터 스토리텔링</li>
+                            <li>문화예술 프로젝트 기획</li>
+                            <li>창의 문제 해결 스프린트</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>실천 커뮤니티 모듈</h3>
+                        <ul>
+                            <li>지역사회 참여 프로젝트</li>
+                            <li>시민 참여형 디자인 씽킹</li>
+                            <li>캡스톤 포트폴리오 제작</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section" role="tabpanel" aria-labelledby="tab-career" tabindex="0">
+            <div class="container department-layout">
+                <h2>학습 성과와 진로 확장</h2>
+                <p>
+                    교양교육과정을 통해 확보한 핵심 역량은 대학 진학 준비, 직무 전환, 지역사회 활동 등 다양한 분야로 확장됩니다.
+                    과정 수료 후에는 학점은행제 학점 인정과 GTCC 평생교육원 인증 포트폴리오 발급이 가능합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>학업 연계</strong>
+                        <p>대학 편입, 전공 탐색, 학점은행제 학습 설계 컨설팅</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>직무 역량</strong>
+                        <p>디지털 소통, 문해력 기반 기획 업무, 공공기관 시민참여 프로그램</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>지역사회 참여</strong>
+                        <p>마을 교육 공동체, 시민 토론회 퍼실리테이터, 문화예술 기획</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section" role="tabpanel" aria-labelledby="tab-support" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학습 지원 서비스</h2>
+                    <p>
+                        전담 튜터가 주간 학습 계획을 점검하고 학습 코칭을 제공하며, 온라인 커뮤니티에서 실시간 피드백을 받을 수 있습니다.
+                        집중 학습 주간에는 오프라인 세미나와 네트워킹 프로그램을 운영해 학습 몰입도를 높입니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>러닝 코칭</h3>
+                        <ul>
+                            <li>학습 성향 진단 및 맞춤 계획 수립</li>
+                            <li>1:1 튜터 미팅 및 실시간 피드백</li>
+                            <li>학습 습관 트래킹 시스템 제공</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>커뮤니티 활동</h3>
+                        <ul>
+                            <li>온라인 토론 & 독서 클럽 운영</li>
+                            <li>지역사회 연계 봉사 프로젝트</li>
+                            <li>GTCC 인사이트 세미나 초청</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="faculty" class="department-section" role="tabpanel" aria-labelledby="tab-faculty" tabindex="0">
+            <div class="container">
+                <div class="department-hero__faculty">
+                    <h2>전담 교수진</h2>
+                    <p class="department-hero__faculty-intro">인문학, 미디어, 시민 교육 분야 전문가가 팀티칭 형태로 교양 역량 개발을 지원합니다.</p>
+                    <div class="department-hero__faculty-list">
+                        <article class="faculty-card">
+                            <figure class="faculty-card__photo">
+                                <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWFmMGZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMzYTZmZjciLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMWYyYTQ0IiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMzYTZmZjciIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="최민서 교수의 프로필 사진" loading="lazy" />
+                            </figure>
+                            <div class="faculty-card__body">
+                                <p class="faculty-card__name">최민서 교수</p>
+                                <p class="faculty-card__role">인문학 · 시민교육</p>
+                                <p class="faculty-card__focus">비판적 사고와 시민 참여 교육을 결합한 프로젝트 수업을 설계합니다.</p>
+                            </div>
+                        </article>
+                        <article class="faculty-card">
+                            <figure class="faculty-card__photo">
+                                <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="박도윤 교수의 프로필 사진" loading="lazy" />
+                            </figure>
+                            <div class="faculty-card__body">
+                                <p class="faculty-card__name">박도윤 교수</p>
+                                <p class="faculty-card__role">디지털 리터러시</p>
+                                <p class="faculty-card__focus">데이터 분석과 미디어 활용 역량을 강화하는 실습 중심 수업을 진행합니다.</p>
+                            </div>
+                        </article>
+                        <article class="faculty-card">
+                            <figure class="faculty-card__photo">
+                                <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWRmN2ZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiM1YmY1ZmQiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMmRhOGZkIiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiM1YmY1ZmQiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="윤하린 교수의 프로필 사진" loading="lazy" />
+                            </figure>
+                            <div class="faculty-card__body">
+                                <p class="faculty-card__name">윤하린 교수</p>
+                                <p class="faculty-card__role">문화예술 교육</p>
+                                <p class="faculty-card__focus">문화예술 프로젝트를 통해 창의적 표현 능력을 이끌어냅니다.</p>
+                            </div>
+                        </article>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/lifelong-professional.html
+++ b/lifelong-professional.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>전문과정 | GTCC 평생교육원</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="평생교육원 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Lifelong Education Program
+                        </span>
+                        <h1>전문과정</h1>
+                        <p>
+                            전문과정은 산업 현장에서 요구하는 실무 역량을 단기간에 확보하도록 설계된 집중 교육 프로그램입니다.
+                            디지털 비즈니스, 융합 공학, 교육 기술 등 산업 맞춤형 트랙으로 구성되어 현장 프로젝트를 통해 실질적인 역량을 완성합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>과정 구분: 직무 · 전문</span>
+                            <span>운영 형태: 온라인+집중 워크숍</span>
+                            <span>이수 기간: 3개월 ~ 9개월</span>
+                        </div>
+                    </div>
+                </div>
+                <nav class="department-tabs" aria-label="전문과정 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">과정 특징</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">트랙 구성</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">산업 연계</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">지원 제도</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">현장 멘토</a>
+                    </div>
+                </nav>
+            </div>
+        </section>
+
+        <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>과정 특징</h2>
+                    <p>
+                        전문과정은 현업 전문가와 협력하여 개발된 실습 중심 커리큘럼으로 구성되어 있습니다.
+                        실시간 라이브 세션과 온·오프라인 협업 스튜디오를 통해 산업 프로젝트를 수행하며 실무 감각을 키웁니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">과정 상담 신청</a>
+                        <a class="btn ghost" href="support.html#coaching">학습 코칭 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">산업 맞춤 설계</h3>
+                            <p class="department-list__subtitle">Industry-Aligned Curriculum</p>
+                            <p class="department-list__body">산업체 자문위원단이 참여해 최신 트렌드를 반영한 과제를 제공합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">프로젝트 실습</h3>
+                            <p class="department-list__subtitle">Hands-on Project Studio</p>
+                            <p class="department-list__body">팀 기반 실습으로 문제 정의, 솔루션 개발, 결과 발표까지 전 과정을 경험합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">현장 멘토링</h3>
+                            <p class="department-list__subtitle">Expert Mentoring</p>
+                            <p class="department-list__body">분야별 멘토가 프로젝트 리뷰와 커리어 코칭을 제공해 취업 경쟁력을 높입니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section" role="tabpanel" aria-labelledby="tab-curriculum" tabindex="0">
+            <div class="container department-layout">
+                <div>
+                    <h2>트랙 구성</h2>
+                    <p>
+                        전문과정은 디지털, 경영, 교육 테크놀로지 세 가지 핵심 트랙으로 구성되어 있으며, 각 트랙은 모듈형 수업과 캡스톤 프로젝트를 포함합니다.
+                        트랙 간 교차 수강이 가능해 개인 맞춤형 전문 역량 조합을 설계할 수 있습니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>디지털 혁신 트랙</h3>
+                        <ul>
+                            <li>AI·데이터 분석 실습</li>
+                            <li>UX/UI 프로토타이핑</li>
+                            <li>클라우드 서비스 아키텍처</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>비즈니스 전략 트랙</h3>
+                        <ul>
+                            <li>애자일 프로젝트 매니지먼트</li>
+                            <li>신사업 기획 워크숍</li>
+                            <li>글로벌 협상 & 프레젠테이션</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>교육테크 트랙</h3>
+                        <ul>
+                            <li>러닝 경험 설계</li>
+                            <li>XR 기반 콘텐츠 제작</li>
+                            <li>스마트러닝 운영 전략</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section" role="tabpanel" aria-labelledby="tab-career" tabindex="0">
+            <div class="container department-layout">
+                <h2>산업 연계 및 진출</h2>
+                <p>
+                    교육기간 동안 파트너 기업과 공동 프로젝트를 수행하고, 산업 전문가 네트워킹 세션을 통해 취업과 창업 기회를 발굴합니다.
+                    우수 수료생에게는 GTCC 산학협력단의 인턴십 및 프로젝트 매칭 프로그램이 제공됩니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>산학 프로젝트</strong>
+                        <p>기업 연계 PBL, 캡스톤 발표회, 현업 멘토 리뷰</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>커리어 지원</strong>
+                        <p>이력서·포트폴리오 컨설팅, 모의 인터뷰, 취업 매칭</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>창업/프리랜스</strong>
+                        <p>스타트업 인큐베이팅, 프리랜서 계약 컨설팅, 네트워크 커뮤니티</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section" role="tabpanel" aria-labelledby="tab-support" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>지원 제도</h2>
+                    <p>
+                        전문 과정 수강생에게는 프로젝트 장비 대여, 소프트웨어 이용권, 학습 코칭 등 맞춤형 지원을 제공합니다.
+                        또한 GTCC 혁신 허브를 활용한 공동 작업 공간과 글로벌 웨비나 참여 기회를 제공합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학습 인프라</h3>
+                        <ul>
+                            <li>전용 온라인 협업 플랫폼 제공</li>
+                            <li>XR 스튜디오 및 장비 대여</li>
+                            <li>전문 소프트웨어 라이선스 지원</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>커리어 서비스</h3>
+                        <ul>
+                            <li>산업 전문가 멘토링</li>
+                            <li>취업 역량 강화 워크숍</li>
+                            <li>기업 설명회 & 네트워킹 데이</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="faculty" class="department-section" role="tabpanel" aria-labelledby="tab-faculty" tabindex="0">
+            <div class="container">
+                <div class="department-hero__faculty">
+                    <h2>현장 멘토</h2>
+                    <p class="department-hero__faculty-intro">각 분야의 실무 전문가가 팀 프로젝트와 커리어 설계를 함께하며 성장을 지원합니다.</p>
+                    <div class="department-hero__faculty-list">
+                        <article class="faculty-card">
+                            <figure class="faculty-card__photo">
+                                <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWFmMGZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiMzYTZmZjciLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMWYyYTQ0IiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiMzYTZmZjciIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="김서준 멘토의 프로필 사진" loading="lazy" />
+                            </figure>
+                            <div class="faculty-card__body">
+                                <p class="faculty-card__name">김서준 멘토</p>
+                                <p class="faculty-card__role">디지털 전략 컨설턴트</p>
+                                <p class="faculty-card__focus">데이터 기반 비즈니스 전략 수립과 스타트업 성장 전략을 지도합니다.</p>
+                            </div>
+                        </article>
+                        <article class="faculty-card">
+                            <figure class="faculty-card__photo">
+                                <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZmZlY2U4Ii8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiNmZjdiNWEiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjOGIzMjFmIiBvcGFjaXR5PSIwLjE4Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiNmZjdiNWEiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="이아린 멘토의 프로필 사진" loading="lazy" />
+                            </figure>
+                            <div class="faculty-card__body">
+                                <p class="faculty-card__name">이아린 멘토</p>
+                                <p class="faculty-card__role">UX 리서처</p>
+                                <p class="faculty-card__focus">사용자 경험 리서치와 서비스 디자인 워크숍을 통해 실무 노하우를 전합니다.</p>
+                            </div>
+                        </article>
+                        <article class="faculty-card">
+                            <figure class="faculty-card__photo">
+                                <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNjAgMTYwIj4KICA8cmVjdCB3aWR0aD0iMTYwIiBoZWlnaHQ9IjE2MCIgcng9IjMyIiBmaWxsPSIjZWRmN2ZmIi8+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSI2MCIgcj0iMzYiIGZpbGw9IiM1YmY1ZmQiLz4KICA8cGF0aCBkPSJNODAgOTZjLTMyIDAtNTggMjAtNTggNDZoMTE2YzAtMjYtMjYtNDYtNTgtNDZ6IiBmaWxsPSIjMmRhOGZkIiBvcGFjaXR5PSIwLjE2Ii8+CiAgPHBhdGggZD0iTTgwIDk2Yy0yNCAwLTQ0IDE0LTUxIDM0aDEwMmMtNy0yMC0yNy0zNC01MS0zNHoiIGZpbGw9IiM1YmY1ZmQiIG9wYWNpdHk9IjAuMjgiLz4KPC9zdmc+Cg==" alt="정이안 멘토의 프로필 사진" loading="lazy" />
+                            </figure>
+                            <div class="faculty-card__body">
+                                <p class="faculty-card__name">정이안 멘토</p>
+                                <p class="faculty-card__role">교육테크 기획자</p>
+                                <p class="faculty-card__focus">교육테크 서비스 기획과 운영 노하우를 바탕으로 현장 적용 전략을 제시합니다.</p>
+                            </div>
+                        </article>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated pages for the lifelong education liberal arts, professional, certification, and commissioned programs using the department template
- update the 평생교육원 mega menu to link to the new program pages and quick access resources

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e5ffc2168c8332a83cda3f37f456c5