### PR TITLE
Add university-style templates for lifelong education subpages

### DIFF
--- a/assets/partials/header.html
+++ b/assets/partials/header.html
@@ -182,9 +182,9 @@
                                 <section class="mega-section">
                                     <h3>교양교육과정</h3>
                                     <ul>
-                                        <li><a href="convergence.html#curriculum">교양아카데미</a></li>
-                                        <li><a href="convergence.html#curriculum">국가및민간자격</a></li>
-                                        <li><a href="convergence.html#curriculum">국제민간자격</a></li>
+                                        <li><a href="lifelong-liberal-academy.html">교양아카데미</a></li>
+                                        <li><a href="lifelong-national-qualifications.html">국가및민간자격</a></li>
+                                        <li><a href="lifelong-international-qualifications.html">국제민간자격</a></li>
                                     </ul>
                                 </section>
                                 <section class="mega-section">
@@ -195,17 +195,17 @@
                                 <section class="mega-section">
                                     <h3>전문,자격과정</h3>
                                     <ul>
-                                        <li><a href="convergence.html#business">테솔과정</a></li>
-                                        <li><a href="convergence.html#business">영어마스터과정</a></li>
-                                        <li><a href="convergence.html#business">기타전문자격과정</a></li>
+                                        <li><a href="lifelong-tesol.html">테솔과정</a></li>
+                                        <li><a href="lifelong-english-master.html">영어마스터과정</a></li>
+                                        <li><a href="lifelong-professional-certifications.html">기타전문자격과정</a></li>
                                     </ul>
                                 </section>
                                 <section class="mega-section">
                                     <h3>위탁 과정</h3>
                                     <ul>
-                                        <li><a href="convergence.html#tech">실습지원센터</a></li>
-                                        <li><a href="convergence.html#tech">편입학위과정</a></li>
-                                        <li><a href="convergence.html#tech">학습지원센터</a></li>
+                                        <li><a href="lifelong-practicum-center.html">실습지원센터</a></li>
+                                        <li><a href="lifelong-transfer-degree.html">편입학위과정</a></li>
+                                        <li><a href="lifelong-learning-support-center.html">학습지원센터</a></li>
                                     </ul>
                                 </section>
                             </div>

--- a/lifelong-english-master.html
+++ b/lifelong-english-master.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>영어 마스터 과정 | GTCC 평생교육원</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="평생교육 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Lifelong Learning Program
+                        </span>
+                        <h1>영어 마스터 과정</h1>
+                        <p>
+                            영어 마스터 과정은 글로벌 비즈니스와 학업, 자격 취득에 필요한 고급 영어 역량을 체계적으로 강화합니다.
+                            몰입형 스피킹, 아카데믹 라이팅, 실무 프레젠테이션 모듈로 구성된 실전 중심 영어 전문 프로그램입니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>교육유형: 집중어학</span>
+                            <span>소속: 평생교육원</span>
+                            <span>표준수업기간: 4~6개월</span>
+                        </div>
+                    </div>
+                </div>
+                <nav class="department-tabs" aria-label="영어 마스터 과정 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">과정소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">커리큘럼</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">활용 분야</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학습지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">전담 코치</a>
+                    </div>
+                </nav>
+            </div>
+        </section>
+
+        <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>과정소개</h2>
+                    <p>
+                        영어 4대 영역을 균형 있게 강화하며, 개인별 레벨 진단과 맞춤 학습 경로를 제공합니다.
+                        실시간 소그룹 수업과 AI 발음 코칭을 결합하여 단기간에 실력 향상을 경험할 수 있습니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">수강 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">수강료 · 장학 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">몰입 스피킹</h3>
+                            <p class="department-list__subtitle">Immersive Speaking</p>
+                            <p class="department-list__body">원어민 코치와의 주제별 토론, 발표, 실시간 피드백으로 자신감을 높입니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">아카데믹 라이팅</h3>
+                            <p class="department-list__subtitle">Academic Writing</p>
+                            <p class="department-list__body">에세이, 리포트, 연구 발표문 등 학문적 글쓰기 능력을 체계적으로 강화합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">비즈니스 커뮤니케이션</h3>
+                            <p class="department-list__subtitle">Business Communication</p>
+                            <p class="department-list__body">글로벌 비즈니스 이메일, 프레젠테이션, 협상 커뮤니케이션을 실습합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section" role="tabpanel" aria-labelledby="tab-curriculum" tabindex="0">
+            <div class="container department-layout">
+                <div>
+                    <h2>커리큘럼 구성</h2>
+                    <p>
+                        레벨 기반 코어 모듈과 목적별 특화 트랙으로 구성되어 있으며, 주간 평가와 학습 분석 리포트로 실력 향상을 관리합니다.
+                        온라인과 오프라인 세션을 병행하여 유연한 학습 경험을 제공합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>코어 모듈</h3>
+                        <ul>
+                            <li>Speaking &amp; Pronunciation Lab</li>
+                            <li>Reading &amp; Vocabulary Builder</li>
+                            <li>Writing &amp; Grammar Clinic</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>특화 트랙</h3>
+                        <ul>
+                            <li>TOEIC/TOEFL 집중반</li>
+                            <li>Business Presentation Clinic</li>
+                            <li>Academic Research Writing</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>성과 관리</h3>
+                        <ul>
+                            <li>주간 레벨 테스트</li>
+                            <li>AI 발음 &amp; 억양 분석</li>
+                            <li>맞춤 학습 리포트</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section" role="tabpanel" aria-labelledby="tab-career" tabindex="0">
+            <div class="container department-layout">
+                <h2>활용 분야</h2>
+                <p>
+                    영어 마스터 과정을 통해 취업, 해외 유학, 글로벌 프로젝트 등에서 요구되는 고급 영어 역량을 확보할 수 있습니다.
+                    영어 기반 자격시험 준비와 해외 진학 포트폴리오 구축을 동시에 진행할 수 있도록 지원합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>글로벌 커리어</strong>
+                        <p>해외 취업, 다국적 기업 입사, 글로벌 프로젝트 수행</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>학업 &amp; 연구</strong>
+                        <p>해외 대학/대학원 진학, 국제 학술 발표, 연구 논문 작성</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>자격시험 준비</strong>
+                        <p>TOEIC, TOEFL, IELTS, OPIc, TEPS 등 고득점 달성</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section" role="tabpanel" aria-labelledby="tab-support" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학습 지원 프로그램</h2>
+                    <p>
+                        개인 튜터링, 학습 코칭, 실전 모의 면접 등 학습 목적에 맞춘 지원 서비스를 제공합니다.
+                        학습 데이터 기반 리포트와 목표 달성 로드맵으로 지속적인 성장을 돕습니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>튜터링</h3>
+                        <ul>
+                            <li>개인 스피킹 튜터링</li>
+                            <li>아카데믹 라이팅 피드백</li>
+                            <li>실시간 발음 교정</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>학습 코칭</h3>
+                        <ul>
+                            <li>주간 학습 플래너</li>
+                            <li>목표 달성 체크인</li>
+                            <li>학습 데이터 리포트</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>커리어 연계</h3>
+                        <ul>
+                            <li>영문 이력서/자기소개서 컨설팅</li>
+                            <li>국제 면접 대비 클리닉</li>
+                            <li>해외 진학/취업 멘토링</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="faculty" class="department-section" role="tabpanel" aria-labelledby="tab-faculty" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>전담 코치</h2>
+                    <p class="department-hero__faculty-intro">
+                        원어민 및 이중언어 전문가, 시험 대비 코치, 비즈니스 커뮤니케이션 전문가가 팀티칭으로 참여합니다.
+                        학습자의 목표에 따라 맞춤 코칭을 제공하고 성장 경로를 함께 설계합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>코칭 팀</h3>
+                        <ul>
+                            <li>Native Speaker Coach – 실시간 스피킹 튜터링</li>
+                            <li>Academic Writing Specialist – 논문/에세이 지도</li>
+                            <li>Business Communication Trainer – 프레젠테이션 코칭</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>지원 네트워크</h3>
+                        <ul>
+                            <li>해외 대학 동문 멘토</li>
+                            <li>국제 기업 현직자 커뮤니티</li>
+                            <li>시험 고득점 합격생 스터디 리더</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/lifelong-international-qualifications.html
+++ b/lifelong-international-qualifications.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>국제 민간자격 과정 | GTCC 평생교육원</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="평생교육 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Lifelong Learning Program
+                        </span>
+                        <h1>국제 민간자격 과정</h1>
+                        <p>
+                            글로벌 자격 인증 기관과 협력하여 TESOL, 국제 코칭, 글로벌 비즈니스 자격 등 해외 인정 민간 자격 취득을 지원합니다.
+                            전 과정 영어·한국어 이중 언어 학습과 국제 온라인 시험 대비를 제공하여 해외 진출 경쟁력을 높입니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>교육유형: 국제자격</span>
+                            <span>소속: 평생교육원</span>
+                            <span>표준수업기간: 4~8개월</span>
+                        </div>
+                    </div>
+                </div>
+                <nav class="department-tabs" aria-label="국제 민간자격 과정 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">과정소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">커리큘럼</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">글로벌 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">지원서비스</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">전문 교수진</a>
+                    </div>
+                </nav>
+            </div>
+        </section>
+
+        <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>과정소개</h2>
+                    <p>
+                        국제 자격 인증 기준을 반영한 커리큘럼으로 시험 준비부터 실습, 인증 신청까지 전 과정을 지원합니다.
+                        해외 교수진의 라이브 세미나와 글로벌 동료 학습 커뮤니티를 통해 국제 감각을 갖춘 전문가를 양성합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">수강료 · 인증 비용 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">국제 시험 대비</h3>
+                            <p class="department-list__subtitle">Global Exam Prep</p>
+                            <p class="department-list__body">시험 형식 분석, 모의 테스트, 영어 면접 대비를 통해 합격률을 높입니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">실습 &amp; 포트폴리오</h3>
+                            <p class="department-list__subtitle">Practicum Portfolio</p>
+                            <p class="department-list__body">국제 기준에 맞춘 실습 과제와 멀티미디어 포트폴리오 제작을 지원합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">글로벌 네트워킹</h3>
+                            <p class="department-list__subtitle">Global Networking</p>
+                            <p class="department-list__body">해외 기관과의 프로젝트, 동문 네트워크, 취업 매칭을 제공합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section" role="tabpanel" aria-labelledby="tab-curriculum" tabindex="0">
+            <div class="container department-layout">
+                <div>
+                    <h2>커리큘럼 구성</h2>
+                    <p>
+                        국제 자격 취득에 필요한 이론, 실습, 인증 준비 단계로 구성되었습니다.
+                        글로벌 파트너 기관과 공동 개발한 콘텐츠로 실무 역량과 언어 능력을 동시에 향상합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>글로벌 이론</h3>
+                        <ul>
+                            <li>국제 표준 커리큘럼 이해</li>
+                            <li>영어 전문 용어 &amp; 커뮤니케이션</li>
+                            <li>케이스 스터디 분석</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>실습 프로젝트</h3>
+                        <ul>
+                            <li>국제 실습 과제 수행</li>
+                            <li>동료 피드백 기반 개선</li>
+                            <li>온라인 실시간 워크숍</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>인증 준비</h3>
+                        <ul>
+                            <li>모의 시험 &amp; 인증 서류 작성</li>
+                            <li>자격 심사 인터뷰 코칭</li>
+                            <li>해외 시험 일정 관리</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section" role="tabpanel" aria-labelledby="tab-career" tabindex="0">
+            <div class="container department-layout">
+                <h2>글로벌 진출 경로</h2>
+                <p>
+                    국제 자격 취득을 통해 해외 교육기관, 국제기구, 글로벌 기업에서 전문 역량을 인정받을 수 있습니다.
+                    해외 취업, 원격 근무, 글로벌 창업 등 다양한 커리어 경로를 지원합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>해외 교육기관</strong>
+                        <p>TESOL 강의, 국제학교 교원, 언어 교육 컨설턴트</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>글로벌 기업</strong>
+                        <p>글로벌 HRD, 다국적 기업 연수 기획, 국제 프로젝트 매니저</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>국제기구·NGO</strong>
+                        <p>국제 개발 교육, 다문화 커뮤니티 지원, 비영리 프로젝트 매니저</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section" role="tabpanel" aria-labelledby="tab-support" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>국제 지원 서비스</h2>
+                    <p>
+                        시험 일정 안내, 서류 번역, 해외 시험장 예약 등 국제 자격 취득을 위한 전담 코디네이션을 제공합니다.
+                        비자, 체류 준비, 해외 취업 상담까지 원스톱 서비스를 지원합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>시험 코디네이션</h3>
+                        <ul>
+                            <li>시험 일정 &amp; 신청 대행</li>
+                            <li>응시 서류 번역 지원</li>
+                            <li>온라인 시험 환경 점검</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>언어 지원</h3>
+                        <ul>
+                            <li>영어 인터뷰 클리닉</li>
+                            <li>영작 교정 &amp; 피드백</li>
+                            <li>발음 &amp; 스피치 코칭</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>해외 진출</h3>
+                        <ul>
+                            <li>취업/인턴십 매칭</li>
+                            <li>비자·체류 컨설팅</li>
+                            <li>글로벌 동문 네트워크</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="faculty" class="department-section" role="tabpanel" aria-labelledby="tab-faculty" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>전문 교수진</h2>
+                    <p class="department-hero__faculty-intro">
+                        해외 대학 교수, 국제 인증 심사위원, 글로벌 기업 트레이너 등 국제 현장 경험이 풍부한 전문가들이 직접 지도합니다.
+                        문화 간 커뮤니케이션 역량과 글로벌 리더십을 키우는 맞춤형 멘토링을 제공합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>글로벌 강사진</h3>
+                        <ul>
+                            <li>국제 TESOL 협회 인증 강사</li>
+                            <li>ICF 공인 코치</li>
+                            <li>다국적 기업 교육 디렉터</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>멘토링 네트워크</h3>
+                        <ul>
+                            <li>해외 동문 멘토단</li>
+                            <li>국제 자격 시험 합격생 멘토</li>
+                            <li>글로벌 커리어 코치</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/lifelong-learning-support-center.html
+++ b/lifelong-learning-support-center.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>학습지원센터 | GTCC 평생교육원</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="평생교육 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Lifelong Learning Program
+                        </span>
+                        <h1>학습지원센터</h1>
+                        <p>
+                            학습지원센터는 평생교육원 학습자의 학업 성취와 진로 목표 달성을 돕는 통합 지원 허브입니다.
+                            학습 코칭, 상담, 정보 서비스를 제공하여 자기주도 학습과 성공적인 과정 이수를 지원합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>서비스유형: 학습지원</span>
+                            <span>소속: 평생교육원</span>
+                            <span>운영시간: 주중 09:00~21:00</span>
+                        </div>
+                    </div>
+                </div>
+                <nav class="department-tabs" aria-label="학습지원센터 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">센터소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">지원 서비스</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 상담</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">이용 절차</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">전담 코치</a>
+                    </div>
+                </nav>
+            </div>
+        </section>
+
+        <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>센터소개</h2>
+                    <p>
+                        학습지원센터는 학습 상담, 학습법 워크숍, 디지털 학습 도구 안내를 통해 학습자의 성장을 돕습니다.
+                        학사 일정 관리와 학습자 커뮤니티 운영으로 지속적인 동기 부여와 참여를 촉진합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="support.html">상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">지원 프로그램 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">학습 상담</h3>
+                            <p class="department-list__subtitle">Learning Coaching</p>
+                            <p class="department-list__body">학습 성향 분석과 목표 설정을 통해 맞춤형 학습 전략을 제시합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">학습법 워크숍</h3>
+                            <p class="department-list__subtitle">Study Skills Workshop</p>
+                            <p class="department-list__body">시간 관리, 노트테이킹, 협업 학습 등 실용적인 학습법을 훈련합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">학습 지원 도구</h3>
+                            <p class="department-list__subtitle">Learning Resources</p>
+                            <p class="department-list__body">학습 플랫폼 사용법, 자료 검색, 학습 분석 리포트 활용을 안내합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section" role="tabpanel" aria-labelledby="tab-curriculum" tabindex="0">
+            <div class="container department-layout">
+                <div>
+                    <h2>지원 서비스</h2>
+                    <p>
+                        학습 목표 달성을 위한 맞춤형 지원 서비스를 제공하며, 온라인/오프라인 상담 채널을 운영합니다.
+                        학습자 요구에 따라 1:1 상담, 그룹 워크숍, 디지털 자료실을 활용할 수 있습니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학습 코칭</h3>
+                        <ul>
+                            <li>학습 계획 수립</li>
+                            <li>주간 학습 리포트 피드백</li>
+                            <li>학습 몰입 코칭</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>그룹 프로그램</h3>
+                        <ul>
+                            <li>학습법 워크숍</li>
+                            <li>스터디 그룹 매칭</li>
+                            <li>테마별 학습 커뮤니티</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>디지털 지원</h3>
+                        <ul>
+                            <li>온라인 자료실</li>
+                            <li>학습 관리 시스템 안내</li>
+                            <li>AI 학습 도구 활용 교육</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section" role="tabpanel" aria-labelledby="tab-career" tabindex="0">
+            <div class="container department-layout">
+                <h2>진로 상담</h2>
+                <p>
+                    학습지원센터는 진로 코칭, 취업 컨설팅, 자격연계 안내를 통해 학습자의 커리어 개발을 돕습니다.
+                    진로 적성 진단과 경력 포트폴리오 설계를 통해 실질적인 목표 달성을 지원합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>진로 코칭</strong>
+                        <p>진로 적성 검사, 커리어 로드맵 설계, 목표 점검</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>취업 지원</strong>
+                        <p>이력서/자소서 컨설팅, 면접 코칭, 채용 정보 제공</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>자격 연계</strong>
+                        <p>자격 취득 로드맵, 실습/인턴십 안내, 네트워킹 이벤트</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section" role="tabpanel" aria-labelledby="tab-support" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>이용 절차</h2>
+                    <p>
+                        온라인 예약 시스템을 통해 상담과 프로그램을 신청할 수 있으며, 사전 설문을 통해 학습 필요를 진단합니다.
+                        상담 후 맞춤형 액션 플랜과 후속 지원을 제공하여 학습 성장을 지속적으로 모니터링합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>신청 단계</h3>
+                        <ul>
+                            <li>온라인 예약</li>
+                            <li>사전 설문 작성</li>
+                            <li>학습 목표 상담</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>진행 단계</h3>
+                        <ul>
+                            <li>맞춤형 코칭 세션</li>
+                            <li>중간 점검 &amp; 피드백</li>
+                            <li>학습 자료 제공</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>후속 단계</h3>
+                        <ul>
+                            <li>성과 평가 리포트</li>
+                            <li>후속 프로그램 연계</li>
+                            <li>커뮤니티 활동 참여</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="faculty" class="department-section" role="tabpanel" aria-labelledby="tab-faculty" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>전담 코치</h2>
+                    <p class="department-hero__faculty-intro">
+                        학습 코치, 진로 상담사, 심리 상담사가 팀을 이루어 학습자의 목표 달성을 지원합니다.
+                        정기적인 팀 회의를 통해 학습자의 진척을 공유하고 개인 맞춤 솔루션을 제공합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학습 코치진</h3>
+                        <ul>
+                            <li>학습전략 전문가</li>
+                            <li>디지털 학습 코디네이터</li>
+                            <li>평생교육 상담사</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>지원 네트워크</h3>
+                        <ul>
+                            <li>심리상담 전문가</li>
+                            <li>취업 컨설턴트</li>
+                            <li>동문 멘토단</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/lifelong-liberal-academy.html
+++ b/lifelong-liberal-academy.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>교양아카데미 | GTCC 평생교육원</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="평생교육 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Lifelong Learning Program
+                        </span>
+                        <h1>교양아카데미</h1>
+                        <p>
+                            교양아카데미는 인문·사회·문화 예술 분야의 융합 교양을 통해 평생 학습 역량을 강화하고, 지역 사회와 함께 성장하는 시민 리더를 양성합니다.
+                            야간·주말 과정과 온라인 학습을 결합하여 누구나 접근 가능한 열린 교육을 제공합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>교육유형: 교양교육</span>
+                            <span>소속: 평생교육원</span>
+                            <span>표준수업기간: 6~12개월</span>
+                        </div>
+                    </div>
+                </div>
+                <nav class="department-tabs" aria-label="교양아카데미 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">과정소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">커리큘럼</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">성과 및 진로</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학습지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">전담 교수진</a>
+                    </div>
+                </nav>
+            </div>
+        </section>
+
+        <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>과정소개</h2>
+                    <p>
+                        시민 교양, 문화예술, 미래사회를 주제로 한 융합 강좌와 프로젝트를 통해 비판적 사고와 창의적 표현 능력을 함께 기릅니다.
+                        강의, 토론, 현장 체험을 결합하여 학습자의 자기주도성을 높이고 지역 공동체와의 연계를 강화합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">과정 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">수강료 · 장학 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">인문학 탐구</h3>
+                            <p class="department-list__subtitle">Humanities Lab</p>
+                            <p class="department-list__body">철학, 역사, 문학을 통합한 인문학 세미나로 삶과 사회를 읽는 시각을 넓힙니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">문화예술 감성</h3>
+                            <p class="department-list__subtitle">Culture & Arts Studio</p>
+                            <p class="department-list__body">뮤지엄 투어, 공연 감상, 문화기획 워크숍을 통해 감성 역량과 기획력을 함께 키웁니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">미래 역량 프로젝트</h3>
+                            <p class="department-list__subtitle">Future Competency Project</p>
+                            <p class="department-list__body">디지털 리터러시, 지속가능성, 시민참여 프로젝트를 통해 문제 해결 능력을 강화합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section" role="tabpanel" aria-labelledby="tab-curriculum" tabindex="0">
+            <div class="container department-layout">
+                <div>
+                    <h2>커리큘럼 구성</h2>
+                    <p>
+                        기본 교양, 융합 선택, 현장 프로젝트로 구성된 단계별 학습 로드맵을 제공합니다.
+                        온라인 학습과 오프라인 세미나를 연계하여 자기주도 학습 경험을 설계합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>기초 교양 모듈</h3>
+                        <ul>
+                            <li>철학과 인간 이해</li>
+                            <li>미디어 리터러시</li>
+                            <li>글로벌 시민의식</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>융합 선택 모듈</h3>
+                        <ul>
+                            <li>문화예술 창작 워크숍</li>
+                            <li>도시와 공간 스토리텔링</li>
+                            <li>디지털 휴머니티스</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 체험 모듈</h3>
+                        <ul>
+                            <li>박물관/공연 현장 실습</li>
+                            <li>지역사회 참여 프로젝트</li>
+                            <li>포트폴리오 발표회</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section" role="tabpanel" aria-labelledby="tab-career" tabindex="0">
+            <div class="container department-layout">
+                <h2>성과 및 진로 연계</h2>
+                <p>
+                    교양아카데미 이수자는 문화기획, 시민교육, 공공기관 평생학습 프로그램 등 다양한 분야로 활동 영역을 확장합니다.
+                    지역 문화 축제, 평생교육 강사, 시민 토론회 진행자로 진출하며 자기주도형 커리어를 설계할 수 있습니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>문화 기획</strong>
+                        <p>지역 문화행사 기획 및 운영, 문화예술 교육 프로그램 개발</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>평생학습</strong>
+                        <p>시민대학 강사, 공공기관 교양 교육 과정 운영</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>사회 참여</strong>
+                        <p>시민포럼 진행자, 지속가능성 캠페인 기획</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section" role="tabpanel" aria-labelledby="tab-support" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학습 지원 프로그램</h2>
+                    <p>
+                        학습 코칭, 독서클럽, 문화 현장 탐방 등 다양한 활동으로 학습 몰입도를 높입니다.
+                        전문 멘토와의 그룹 피드백을 통해 포트폴리오를 완성하고 향후 진로 설계를 돕습니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학습 코칭</h3>
+                        <ul>
+                            <li>학습 목표 설정 워크숍</li>
+                            <li>독서토론 &amp; 글쓰기 클리닉</li>
+                            <li>자기주도 학습 코칭</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 체험</h3>
+                        <ul>
+                            <li>문화예술 기관 탐방</li>
+                            <li>전시/공연 리뷰 세션</li>
+                            <li>커뮤니티 프로젝트 멘토링</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>커리어 네트워크</h3>
+                        <ul>
+                            <li>평생교육 전문가 특강</li>
+                            <li>지역사회 파트너십 매칭</li>
+                            <li>학습 성과 공유회</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="faculty" class="department-section" role="tabpanel" aria-labelledby="tab-faculty" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>전담 교수진</h2>
+                    <p class="department-hero__faculty-intro">
+                        인문학, 문화예술, 시민교육 전문가로 구성된 교수진이 학습자의 역량과 목표에 맞춘 맞춤형 학습을 지원합니다.
+                        프로젝트별 멘토링과 현장 네트워크를 통해 실천적 교양 교육을 실현합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>주요 교수진</h3>
+                        <ul>
+                            <li>김은정 교수 – 인문학 기반 교양교육 설계</li>
+                            <li>박도현 교수 – 문화예술 기획 및 커뮤니티 아트</li>
+                            <li>최가람 교수 – 시민교육 및 사회혁신 프로젝트</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>멘토진</h3>
+                        <ul>
+                            <li>문화재단 프로그램 디렉터</li>
+                            <li>지역 도서관 시민대학 코디네이터</li>
+                            <li>사회적기업 교육 콘텐츠 기획자</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/lifelong-national-qualifications.html
+++ b/lifelong-national-qualifications.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>국가·민간자격 통합과정 | GTCC 평생교육원</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="평생교육 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Lifelong Learning Program
+                        </span>
+                        <h1>국가·민간자격 통합과정</h1>
+                        <p>
+                            국가공인 및 민간 전문 자격 취득을 목표로 시험 대비, 실무 실습, 온라인 스터디를 통합한 집중형 교육과정입니다.
+                            자격별 학습 로드맵과 멘토링을 제공하여 단기간 내 자격 취득을 지원합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>교육유형: 자격취득</span>
+                            <span>소속: 평생교육원</span>
+                            <span>표준수업기간: 3~6개월</span>
+                        </div>
+                    </div>
+                </div>
+                <nav class="department-tabs" aria-label="국가·민간자격 통합과정 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">과정소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">커리큘럼</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">자격 활용</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학습지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">전문 교수진</a>
+                    </div>
+                </nav>
+            </div>
+        </section>
+
+        <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>과정소개</h2>
+                    <p>
+                        공인중개사, 사회복지사, 평생교육사 등 대표 자격과 산업 수요가 높은 민간 자격을 통합 지원합니다.
+                        CBT 모의고사, 오프라인 특강, 실무 실습을 결합하여 합격률을 높이고 현장 활용 능력을 강화합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">합격 컨설팅 신청</a>
+                        <a class="btn ghost" href="support.html#guide">수강료 · 환급 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">국가자격 집중반</h3>
+                            <p class="department-list__subtitle">National License Track</p>
+                            <p class="department-list__body">기출 분석, 영역별 특강, 법령 업데이트 강의를 통해 국가자격 합격을 지원합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">민간자격 실무반</h3>
+                            <p class="department-list__subtitle">Private Certification Track</p>
+                            <p class="department-list__body">자격별 실습 키트와 사례 기반 워크숍으로 현장 적용력을 높입니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">스터디 &amp; 멘토링</h3>
+                            <p class="department-list__subtitle">Mentoring Studio</p>
+                            <p class="department-list__body">전문 멘토와의 학습 일정 관리, 온라인 스터디, 커뮤니티 코칭을 운영합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section" role="tabpanel" aria-labelledby="tab-curriculum" tabindex="0">
+            <div class="container department-layout">
+                <div>
+                    <h2>커리큘럼 구성</h2>
+                    <p>
+                        시험 이론, 문제풀이, 실무 실습의 3단계 구성으로 자격 취득과 실무 역량을 동시에 강화합니다.
+                        온라인 강의와 주말 오프라인 특강을 병행하여 학습 효율을 극대화합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>이론 완성</h3>
+                        <ul>
+                            <li>자격별 기본 이론 완성 강의</li>
+                            <li>법령·정책 최신 업데이트</li>
+                            <li>핵심 요약 노트 제공</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>문제풀이 실전</h3>
+                        <ul>
+                            <li>CBT 모의고사 &amp; 해설</li>
+                            <li>기출 유형 집중 분석</li>
+                            <li>개인별 취약영역 클리닉</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>실무 역량</h3>
+                        <ul>
+                            <li>현장 실습 &amp; 케이스 스터디</li>
+                            <li>자격 취득 후 업무 시뮬레이션</li>
+                            <li>취업/창업 컨설팅</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section" role="tabpanel" aria-labelledby="tab-career" tabindex="0">
+            <div class="container department-layout">
+                <h2>자격 활용 분야</h2>
+                <p>
+                    취득 자격에 따라 공공기관, 복지기관, 교육기관, 기업 컨설팅 등 다양한 현장에서 전문 역량을 발휘할 수 있습니다.
+                    자격 업그레이드와 경력 설계를 위한 후속 교육과정도 연계 제공합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>공공·행정 분야</strong>
+                        <p>공공기관 계약직, 지역평생교육센터, 주민자치센터 프로그램 운영</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>복지·교육 분야</strong>
+                        <p>사회복지관, 학교 밖 청소년 지원센터, 평생교육사 활동</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>컨설팅·창업</strong>
+                        <p>자격 전문 강의, 프랜차이즈 컨설팅, 온라인 교육 창업</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section" role="tabpanel" aria-labelledby="tab-support" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학습 지원 서비스</h2>
+                    <p>
+                        주간 학습 플래너, 1:1 학습 상담, 시험 직전 집중 캠프 등 맞춤형 지원으로 학습 몰입도를 높입니다.
+                        자격증 취득 후 진로 설계를 위한 경력 코칭과 취업 지원을 제공합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학습 관리</h3>
+                        <ul>
+                            <li>주간 학습 플래너 제공</li>
+                            <li>출석·진도 자동 알림</li>
+                            <li>시험 대비 실시간 Q&amp;A</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>집중 캠프</h3>
+                        <ul>
+                            <li>주말 핵심 요약 특강</li>
+                            <li>직전 모의고사 캠프</li>
+                            <li>멘토 피드백 세션</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>경력 지원</h3>
+                        <ul>
+                            <li>취업/창업 컨설팅</li>
+                            <li>자격 활용 네트워킹</li>
+                            <li>심화 과정 연계 안내</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="faculty" class="department-section" role="tabpanel" aria-labelledby="tab-faculty" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>전문 교수진</h2>
+                    <p class="department-hero__faculty-intro">
+                        각 자격 분야의 현직 전문가와 합격 컨설턴트가 참여하여 시험 전략과 실무 노하우를 동시에 전수합니다.
+                        합격 이후 현장 적응까지 연계 지원하는 멘토링 시스템을 운영합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>자격별 책임 강사</h3>
+                        <ul>
+                            <li>법령 파트 – 전직 공공기관 정책 전문가</li>
+                            <li>실무 파트 – 사회복지 현장 슈퍼바이저</li>
+                            <li>학습 전략 – 자격 전문 컨설턴트</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>지원 멘토</h3>
+                        <ul>
+                            <li>합격생 커뮤니티 운영진</li>
+                            <li>산업계 실무 멘토단</li>
+                            <li>경력개발 코치</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/lifelong-practicum-center.html
+++ b/lifelong-practicum-center.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>실습지원센터 | GTCC 평생교육원</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="평생교육 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Lifelong Learning Program
+                        </span>
+                        <h1>실습지원센터</h1>
+                        <p>
+                            실습지원센터는 평생교육원 과정 이수자들의 현장 실습과 인턴십을 체계적으로 관리하고 지원하는 전담 조직입니다.
+                            실습 매칭, 행정 지원, 안전 교육을 통합 제공하여 안정적인 현장 경험을 돕습니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>서비스유형: 현장실습 지원</span>
+                            <span>소속: 평생교육원</span>
+                            <span>지원기간: 상시</span>
+                        </div>
+                    </div>
+                </div>
+                <nav class="department-tabs" aria-label="실습지원센터 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">센터소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">지원 프로그램</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">현장 네트워크</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">이용 안내</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">전담 코디네이터</a>
+                    </div>
+                </nav>
+            </div>
+        </section>
+
+        <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>센터소개</h2>
+                    <p>
+                        실습지원센터는 학습자의 전공과 진로 목표에 맞는 현장 실습 기회를 발굴하고, 사전 교육부터 사후 평가까지 전 과정을 지원합니다.
+                        산학협력 기관과의 긴밀한 협력을 통해 안전하고 의미 있는 현장 경험을 제공합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="support.html">실습 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">실습 규정 확인</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">실습 매칭</h3>
+                            <p class="department-list__subtitle">Practicum Matching</p>
+                            <p class="department-list__body">전공별 기업·기관과 협력하여 적합한 실습 기관을 연결합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">행정 지원</h3>
+                            <p class="department-list__subtitle">Administrative Support</p>
+                            <p class="department-list__body">실습 협약, 보험 가입, 실습비 정산 등 행정 절차를 지원합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">성과 관리</h3>
+                            <p class="department-list__subtitle">Performance Coaching</p>
+                            <p class="department-list__body">실습 중간 점검과 평가 코칭을 통해 학습 성과를 점검합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section" role="tabpanel" aria-labelledby="tab-curriculum" tabindex="0">
+            <div class="container department-layout">
+                <div>
+                    <h2>지원 프로그램</h2>
+                    <p>
+                        실습 전·중·후 단계별로 필요한 교육과 지원을 제공하여 현장 적응력을 높입니다.
+                        안전 교육, 직무 교육, 평가 워크숍 등을 통해 실습 품질을 높이고 학습 효과를 극대화합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>사전 준비</h3>
+                        <ul>
+                            <li>실습 오리엔테이션</li>
+                            <li>안전·노무 교육</li>
+                            <li>직무 이해 워크숍</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 지원</h3>
+                        <ul>
+                            <li>현장 코디네이터 배정</li>
+                            <li>주간 점검 &amp; 피드백</li>
+                            <li>문제 상황 대응 지원</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>사후 평가</h3>
+                        <ul>
+                            <li>성과 발표 워크숍</li>
+                            <li>포트폴리오 작성 지원</li>
+                            <li>진로 컨설팅 연계</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section" role="tabpanel" aria-labelledby="tab-career" tabindex="0">
+            <div class="container department-layout">
+                <h2>현장 네트워크</h2>
+                <p>
+                    평생교육원은 교육, 복지, 문화, IT 등 다양한 분야의 기관과 협력하여 실습처를 확보하고 있습니다.
+                    정기적인 협약 확대와 만족도 평가를 통해 우수 기관을 발굴하고 장기 파트너십을 구축합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>교육 기관</strong>
+                        <p>학교, 평생학습관, 에듀테크 기업 연계 실습</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>복지 기관</strong>
+                        <p>사회복지관, 상담센터, 돌봄 서비스 기관 실습</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>산업체 &amp; 문화 기관</strong>
+                        <p>기업 HRD센터, 문화재단, 지역문화센터 프로젝트</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section" role="tabpanel" aria-labelledby="tab-support" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>이용 안내</h2>
+                    <p>
+                        실습지원센터는 학기별 신청을 통해 운영되며, 사전 상담과 서류 심사를 거쳐 배정이 확정됩니다.
+                        실습 전·중·후 필수 제출 서류와 평가 절차를 안내하여 효율적인 실습 운영을 돕습니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>신청 절차</h3>
+                        <ul>
+                            <li>온라인 신청서 제출</li>
+                            <li>사전 상담 및 자격 확인</li>
+                            <li>실습처 매칭 및 협약 체결</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>운영 가이드</h3>
+                        <ul>
+                            <li>주간 보고서 제출</li>
+                            <li>중간 점검 미팅</li>
+                            <li>최종 평가 &amp; 피드백</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>지원 서비스</h3>
+                        <ul>
+                            <li>보험 및 안전 관리</li>
+                            <li>실습비 지원 안내</li>
+                            <li>취업 연계 상담</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="faculty" class="department-section" role="tabpanel" aria-labelledby="tab-faculty" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>전담 코디네이터</h2>
+                    <p class="department-hero__faculty-intro">
+                        실습 지원 전문가와 진로 코치가 협업하여 학습자의 실습 목표 달성을 돕습니다.
+                        현장 방문, 멘토 미팅, 사후 평가 등 체계적인 지원을 제공하며, 실습 경험을 진로와 연결합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>코디네이터 팀</h3>
+                        <ul>
+                            <li>전공별 실습 코디네이터</li>
+                            <li>산학협력 매니저</li>
+                            <li>안전·노무 전문가</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>지원 네트워크</h3>
+                        <ul>
+                            <li>현장 멘토단</li>
+                            <li>졸업생 멘토링 그룹</li>
+                            <li>경력 개발 코칭</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/lifelong-professional-certifications.html
+++ b/lifelong-professional-certifications.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>기타 전문자격 과정 | GTCC 평생교육원</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="평생교육 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Lifelong Learning Program
+                        </span>
+                        <h1>기타 전문자격 과정</h1>
+                        <p>
+                            산업 수요 기반의 실무 전문 자격을 집중적으로 준비할 수 있는 맞춤형 프로그램입니다.
+                            경영·IT·복지·문화 분야 등 다양한 자격 트랙을 제공하며, 현직 전문가 멘토링과 프로젝트 실습을 지원합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>교육유형: 전문자격</span>
+                            <span>소속: 평생교육원</span>
+                            <span>표준수업기간: 3~9개월</span>
+                        </div>
+                    </div>
+                </div>
+                <nav class="department-tabs" aria-label="기타 전문자격 과정 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">과정소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">커리큘럼</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진출 분야</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학습지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">전문 멘토</a>
+                    </div>
+                </nav>
+            </div>
+        </section>
+
+        <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>과정소개</h2>
+                    <p>
+                        데이터 분석, 사회서비스, 문화기획, 코칭 등 분야별 자격 과정을 묶어 맞춤형 로드맵을 제공합니다.
+                        온라인 강의, 실습 워크숍, 현장 프로젝트를 통해 실전 역량을 강화하고 빠른 자격 취득을 지원합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">과정 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">수강료 · 패키지 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">경영·데이터 자격</h3>
+                            <p class="department-list__subtitle">Business &amp; Data Track</p>
+                            <p class="department-list__body">경영지도사, 데이터분석 준전문가(ADsP) 등 비즈니스 역량 강화를 위한 자격 대비</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">복지·상담 자격</h3>
+                            <p class="department-list__subtitle">Human Service Track</p>
+                            <p class="department-list__body">상담심리사, 노인복지상담사 등 사람 중심 서비스 자격 대비</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">문화·창의 자격</h3>
+                            <p class="department-list__subtitle">Culture &amp; Creativity Track</p>
+                            <p class="department-list__body">문화예술교육사, 스토리텔링 지도사 등 창의 융합형 자격 대비</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section" role="tabpanel" aria-labelledby="tab-curriculum" tabindex="0">
+            <div class="container department-layout">
+                <div>
+                    <h2>커리큘럼 구성</h2>
+                    <p>
+                        자격 공통 기본 이론과 자격별 심화 모듈, 실무 프로젝트로 구성된 단계별 학습으로 실전 대비를 돕습니다.
+                        라이브 특강과 온·오프라인 실습을 통해 이론과 실무를 균형 있게 학습합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>공통 기본 모듈</h3>
+                        <ul>
+                            <li>직무 이해 &amp; 최신 트렌드</li>
+                            <li>법규 · 윤리 · 제도</li>
+                            <li>학습 전략 &amp; 타임 매니지먼트</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>자격별 심화</h3>
+                        <ul>
+                            <li>분야별 핵심 이론 특강</li>
+                            <li>실기/서류 준비 워크숍</li>
+                            <li>모의고사 &amp; 피드백</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>현장 프로젝트</h3>
+                        <ul>
+                            <li>산업체 연계 문제 해결</li>
+                            <li>현장 실습 &amp; 사례 발표</li>
+                            <li>포트폴리오 코칭</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section" role="tabpanel" aria-labelledby="tab-career" tabindex="0">
+            <div class="container department-layout">
+                <h2>진출 분야</h2>
+                <p>
+                    자격 취득 후 기업, 공공기관, 사회서비스 기관 등 다양한 현장에서 전문성을 발휘할 수 있습니다.
+                    프리랜서 컨설턴트, 교육 강사, 창업 등 유연한 커리어 설계도 지원합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>비즈니스 컨설팅</strong>
+                        <p>경영·데이터 자격 기반 컨설턴트, 분석가, 프로젝트 매니저</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>복지·상담 서비스</strong>
+                        <p>복지기관, 상담센터, 공공서비스 분야 전문 인력</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>문화·교육 기획</strong>
+                        <p>문화예술교육, 지역문화프로그램, 창의융합 콘텐츠 기획</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section" role="tabpanel" aria-labelledby="tab-support" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학습 지원 서비스</h2>
+                    <p>
+                        자격별 스터디 플랜, 합격 전략 컨설팅, 포트폴리오 진단 등 학습 전 과정을 지원합니다.
+                        자격 취득 후 경력 개발을 위한 인턴십, 취업 연계 프로그램도 함께 제공합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학습 관리</h3>
+                        <ul>
+                            <li>개인별 합격 로드맵 설계</li>
+                            <li>스터디 그룹 매칭</li>
+                            <li>출결 · 진도 모니터링</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>멘토링</h3>
+                        <ul>
+                            <li>현직 전문가 멘토링</li>
+                            <li>자격 실무 Q&amp;A 세션</li>
+                            <li>케이스 스터디 리뷰</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>커리어 지원</h3>
+                        <ul>
+                            <li>취업/창업 컨설팅</li>
+                            <li>현장 실습 연계</li>
+                            <li>자격 갱신 · 심화 과정 안내</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="faculty" class="department-section" role="tabpanel" aria-labelledby="tab-faculty" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>전문 멘토</h2>
+                    <p class="department-hero__faculty-intro">
+                        산업별 실무 전문가와 공인 강사, 자격 컨설턴트가 참여하여 합격 전략과 실무 역량을 동시에 강화합니다.
+                        분야별 협력 기관과의 네트워크를 활용해 현장 경험과 취업 기회를 제공합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>전문가 그룹</h3>
+                        <ul>
+                            <li>데이터 분석 실무자</li>
+                            <li>상담·복지 현장 슈퍼바이저</li>
+                            <li>문화예술교육 기획자</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>지원 네트워크</h3>
+                        <ul>
+                            <li>자격 합격생 커뮤니티</li>
+                            <li>산학 협력 파트너</li>
+                            <li>경력개발 코치</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/lifelong-tesol.html
+++ b/lifelong-tesol.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TESOL 과정 | GTCC 평생교육원</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="평생교육 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Lifelong Learning Program
+                        </span>
+                        <h1>TESOL 과정</h1>
+                        <p>
+                            TESOL 과정은 영어 교수법, 언어 습득 이론, 수업 디자인을 심화 학습하여 글로벌 영어교육 전문가를 양성합니다.
+                            온라인 강의와 실습 수업, 현장 관찰을 통해 실전 수업 능력을 체계적으로 훈련합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>교육유형: 전문자격</span>
+                            <span>소속: 평생교육원</span>
+                            <span>표준수업기간: 6개월</span>
+                        </div>
+                    </div>
+                </div>
+                <nav class="department-tabs" aria-label="TESOL 과정 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">과정소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">커리큘럼</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">진로 및 진출</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학습지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">교수진</a>
+                    </div>
+                </nav>
+            </div>
+        </section>
+
+        <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>과정소개</h2>
+                    <p>
+                        TESOL 핵심 이론과 교수 전략을 실무 중심으로 학습하며, 수업 관찰과 마이크로 티칭으로 강의 역량을 강화합니다.
+                        온라인 영어교육 플랫폼 운영 경험을 통해 디지털 러닝 시대에 필요한 역량을 갖춘 강사를 양성합니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">입학 상담 신청</a>
+                        <a class="btn ghost" href="support.html#guide">수강료 · 장학 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">언어습득 이론</h3>
+                            <p class="department-list__subtitle">Second Language Acquisition</p>
+                            <p class="department-list__body">언어습득 이론과 학습자 분석을 통해 맞춤형 수업 전략을 설계합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">교수법 실습</h3>
+                            <p class="department-list__subtitle">Teaching Practice</p>
+                            <p class="department-list__body">마이크로 티칭, 수업 시연, 피드백 세션으로 교수 역량을 키웁니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">디지털 러닝</h3>
+                            <p class="department-list__subtitle">Digital Learning Design</p>
+                            <p class="department-list__body">온라인 학습 콘텐츠 제작과 학습 분석을 통한 스마트 러닝 수업을 구현합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section" role="tabpanel" aria-labelledby="tab-curriculum" tabindex="0">
+            <div class="container department-layout">
+                <div>
+                    <h2>커리큘럼 구성</h2>
+                    <p>
+                        이론, 실습, 현장 경험으로 연결되는 단계별 학습으로 TESOL 국제 기준에 맞춘 교수 역량을 갖춥니다.
+                        실무형 평가와 포트폴리오를 통해 실제 수업에서 바로 활용 가능한 콘텐츠를 완성합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>이론 모듈</h3>
+                        <ul>
+                            <li>TESOL Foundations</li>
+                            <li>Curriculum Design &amp; Assessment</li>
+                            <li>Language Skills Teaching</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>실습 모듈</h3>
+                        <ul>
+                            <li>Micro Teaching Workshop</li>
+                            <li>Class Observation Report</li>
+                            <li>Teaching Practicum</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>포트폴리오</h3>
+                        <ul>
+                            <li>Lesson Plan Portfolio</li>
+                            <li>EdTech Tool Integration</li>
+                            <li>Capstone Teaching Project</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section" role="tabpanel" aria-labelledby="tab-career" tabindex="0">
+            <div class="container department-layout">
+                <h2>진로 및 진출 분야</h2>
+                <p>
+                    TESOL 자격을 기반으로 국내외 영어교육 기관, 온라인 교육 기업, 국제학교 등 다양한 교육 현장에서 활동할 수 있습니다.
+                    글로벌 교육 커리어 개발과 대학원 진학을 위한 포트폴리오 구축도 함께 지원합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>오프라인 교육</strong>
+                        <p>어학원, 국제학교, 대학 영어강의, 기업체 영어 연수</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>온라인 교육</strong>
+                        <p>온라인 영어교육 플랫폼, 에듀테크 콘텐츠 개발, 실시간 화상수업 강사</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>국제 진출</strong>
+                        <p>해외 영어캠프, 국제 봉사 프로그램, 글로벌 교육 NGO</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section" role="tabpanel" aria-labelledby="tab-support" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학습 지원 프로그램</h2>
+                    <p>
+                        원어민 코칭, 발음 클리닉, 수업 시연 영상 피드백 등 실전 중심의 학습 지원으로 교수 능력을 강화합니다.
+                        교재 설계 워크숍과 취업 코칭으로 현장 진출에 필요한 자료와 전략을 제공합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>코칭 프로그램</h3>
+                        <ul>
+                            <li>원어민 발음 클리닉</li>
+                            <li>티칭 스킬 1:1 코칭</li>
+                            <li>수업 시연 영상 피드백</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>콘텐츠 개발</h3>
+                        <ul>
+                            <li>교수 자료 제작 워크숍</li>
+                            <li>디지털 콘텐츠 디자인</li>
+                            <li>학습자 평가 도구 설계</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>커리어 지원</h3>
+                        <ul>
+                            <li>이력서/포트폴리오 컨설팅</li>
+                            <li>교육기관 취업 설명회</li>
+                            <li>국제 자격 갱신 안내</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="faculty" class="department-section" role="tabpanel" aria-labelledby="tab-faculty" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>교수진</h2>
+                    <p class="department-hero__faculty-intro">
+                        국내외 TESOL 석·박사 출신 교수진과 현직 영어교육 전문가가 참여하여 실전 중심 수업을 운영합니다.
+                        글로벌 교육 현장 경험을 바탕으로 맞춤형 멘토링과 커리어 코칭을 제공합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>주요 교수진</h3>
+                        <ul>
+                            <li>이소피아 교수 – TESOL 커리큘럼 설계 전문가</li>
+                            <li>정우현 교수 – 온라인 영어교육 전략</li>
+                            <li>Rachel Kim Instructor – 원어민 실습 코치</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>멘토 네트워크</h3>
+                        <ul>
+                            <li>국제학교 재직 동문 멘토</li>
+                            <li>에듀테크 기업 교육기획자</li>
+                            <li>해외 캠프 디렉터</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/lifelong-transfer-degree.html
+++ b/lifelong-transfer-degree.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>편입학위과정 | GTCC 평생교육원</title>
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div data-include="assets/partials/header.html"></div>
+
+    <main>
+        <section class="department-hero">
+            <div class="container">
+                <div class="department-hero__layout">
+                    <div class="department-hero__summary">
+                        <span class="department-hero__label" aria-label="평생교육 과정">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l9 4.5-9 4.5-9-4.5L12 3zm0 6.74l7.53-3.77L12 4.2 4.47 5.97 12 9.74zM21 10.5v3.75c0 2.5-4.03 6.25-9 6.25s-9-3.75-9-6.25V10.5l9 4.5 9-4.5z"/></svg>
+                            Lifelong Learning Program
+                        </span>
+                        <h1>편입학위과정</h1>
+                        <p>
+                            편입학위과정은 학점은행제 기반으로 4년제 대학 편입 및 학사 학위 취득을 목표로 하는 학습자를 위한 맞춤 프로그램입니다.
+                            전공 기초부터 심화, 면접 대비까지 통합 로드맵으로 안정적인 학위 취득을 지원합니다.
+                        </p>
+                        <div class="department-meta">
+                            <span>교육유형: 학위연계</span>
+                            <span>소속: 평생교육원</span>
+                            <span>표준수업기간: 1~2년</span>
+                        </div>
+                    </div>
+                </div>
+                <nav class="department-tabs" aria-label="편입학위과정 메뉴">
+                    <div class="department-tabs__list" role="tablist">
+                        <a class="is-active" id="tab-overview" role="tab" aria-controls="overview" aria-selected="true" href="#overview">과정소개</a>
+                        <a id="tab-curriculum" role="tab" aria-controls="curriculum" aria-selected="false" tabindex="-1" href="#curriculum">학습 로드맵</a>
+                        <a id="tab-career" role="tab" aria-controls="career" aria-selected="false" tabindex="-1" href="#career">편입 전략</a>
+                        <a id="tab-support" role="tab" aria-controls="support" aria-selected="false" tabindex="-1" href="#support">학습지원</a>
+                        <a id="tab-faculty" role="tab" aria-controls="faculty" aria-selected="false" tabindex="-1" href="#faculty">전담 교수진</a>
+                    </div>
+                </nav>
+            </div>
+        </section>
+
+        <section id="overview" class="department-section" role="tabpanel" aria-labelledby="tab-overview" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>과정소개</h2>
+                    <p>
+                        학점은행제 수업과 자격, 온라인 강의를 결합하여 빠르고 탄력적인 학위 취득을 지원합니다.
+                        전공별 학습 코치가 학습 설계, 학점 관리, 편입 전략 수립을 1:1로 돕습니다.
+                    </p>
+                    <div class="department-cta">
+                        <a class="btn primary" href="admissions.html">상담 예약</a>
+                        <a class="btn ghost" href="support.html#guide">학점 인정 안내</a>
+                    </div>
+                </div>
+                <div>
+                    <ul class="department-list">
+                        <li>
+                            <h3 class="department-list__title">학점 설계</h3>
+                            <p class="department-list__subtitle">Credit Planning</p>
+                            <p class="department-list__body">전공/교양/일반선택 학점을 균형 있게 배치하여 학위 요건을 충족합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">편입 대비</h3>
+                            <p class="department-list__subtitle">Transfer Preparation</p>
+                            <p class="department-list__body">영어/수학/논술 등 편입 전형에 맞춘 맞춤형 학습을 제공합니다.</p>
+                        </li>
+                        <li>
+                            <h3 class="department-list__title">커리어 설계</h3>
+                            <p class="department-list__subtitle">Career Design</p>
+                            <p class="department-list__body">편입 후 전공 진로 탐색과 포트폴리오를 준비합니다.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section id="curriculum" class="department-section" role="tabpanel" aria-labelledby="tab-curriculum" tabindex="0">
+            <div class="container department-layout">
+                <div>
+                    <h2>학습 로드맵</h2>
+                    <p>
+                        1년·2년 단기 완성 플랜으로 학점 취득, 편입 준비, 학위 신청까지 단계별로 지원합니다.
+                        온라인 수업, 집중 세미나, 모의 면접 등을 통해 실전 대비를 강화합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>Step 1 학점 취득</h3>
+                        <ul>
+                            <li>온라인 전공/교양 수업</li>
+                            <li>자격증 학점 인정</li>
+                            <li>독학사 연계</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>Step 2 편입 준비</h3>
+                        <ul>
+                            <li>편입 전형 분석 세미나</li>
+                            <li>영어/수학 집중반</li>
+                            <li>자기소개서/포트폴리오 작성</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>Step 3 합격 전략</h3>
+                        <ul>
+                            <li>모의 면접 &amp; 면접 클리닉</li>
+                            <li>학과별 합격 사례 분석</li>
+                            <li>학위 신청 행정 지원</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="career" class="department-section" role="tabpanel" aria-labelledby="tab-career" tabindex="0">
+            <div class="container department-layout">
+                <h2>편입 전략</h2>
+                <p>
+                    타깃 대학 맞춤 전략 수립, 전형 일정 관리, 지원 서류 컨설팅 등 실전 대비를 지원합니다.
+                    합격생 네트워크와의 멘토링으로 최신 정보를 공유하고 학습 동기를 유지합니다.
+                </p>
+                <div class="career-grid">
+                    <div class="career-card">
+                        <strong>전형 분석</strong>
+                        <p>대학별 전형요소 비교, 경쟁률 분석, 합격 커트라인 데이터 제공</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>학습 전략</strong>
+                        <p>영어/수학/논술 학습 플랜, 모의고사 성적 분석, 취약 영역 코칭</p>
+                    </div>
+                    <div class="career-card">
+                        <strong>면접 &amp; 서류</strong>
+                        <p>학과별 면접 기출 분석, 모의 면접, 자기소개서/학업계획서 첨삭</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="support" class="department-section" role="tabpanel" aria-labelledby="tab-support" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>학습지원</h2>
+                    <p>
+                        학습 코칭, 학점 관리 시스템, 시험 대비 클리닉 등 학습 전 과정을 지원합니다.
+                        진로 상담과 멘토링으로 편입 후 학업 계획까지 연결합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학습 관리</h3>
+                        <ul>
+                            <li>학점 진행 상황 대시보드</li>
+                            <li>주간 학습 코칭</li>
+                            <li>학사 일정 알림 서비스</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>시험 대비</h3>
+                        <ul>
+                            <li>편입 영어 모의고사</li>
+                            <li>논술/면접 클리닉</li>
+                            <li>스터디 그룹 매칭</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>멘토링</h3>
+                        <ul>
+                            <li>합격생 멘토와의 정기 미팅</li>
+                            <li>편입 후 학업 준비 워크숍</li>
+                            <li>진로 상담 &amp; 커리어 코칭</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section id="faculty" class="department-section" role="tabpanel" aria-labelledby="tab-faculty" tabindex="0">
+            <div class="container department-layout department-layout--split">
+                <div>
+                    <h2>전담 교수진</h2>
+                    <p class="department-hero__faculty-intro">
+                        학점은행제 전문가, 편입 컨설턴트, 전공 교수진이 협력하여 학습자의 목표 달성을 지원합니다.
+                        합격 전략과 학업 역량 강화를 위한 맞춤형 지도를 제공합니다.
+                    </p>
+                </div>
+                <div class="department-cards">
+                    <article class="department-card">
+                        <h3>학습 설계팀</h3>
+                        <ul>
+                            <li>학점은행제 전담 교수</li>
+                            <li>편입 전략 컨설턴트</li>
+                            <li>학사 행정 코디네이터</li>
+                        </ul>
+                    </article>
+                    <article class="department-card">
+                        <h3>멘토링 네트워크</h3>
+                        <ul>
+                            <li>편입 합격생 멘토단</li>
+                            <li>전공별 교수진</li>
+                            <li>진로/경력 코치</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div data-include="assets/partials/footer.html"></div>
+
+    <script src="assets/js/includes.js" defer></script>
+    <script src="assets/js/main.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the 교양교육과정, 전문/자격과정, 위탁 과정 submenu targets with dedicated pages that reuse the 대학 학과 소개 레이아웃
- add tailored TESOL, 영어 마스터, 자격 연계, 실습/학습 지원 콘텐츠 so each 평생교육원 프로그램 mirrors the undergraduate template structure

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e603dcc4f08332abf326b7a2c0f3e7